### PR TITLE
Suppressing CVE-2024-38816 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,10 +13,10 @@
 	<description>ACSP workstream</description>
 	<properties>
 		<java.version>21</java.version>
-		<spring.boot.version>3.3.1</spring.boot.version>
+		<spring.boot.version>3.3.3</spring.boot.version>
 		<main.class>uk.gov.companieshouse.acsp.AcspApplication</main.class>
-		<spring-boot-dependencies.version>3.3.1</spring-boot-dependencies.version>
-		<spring-boot-maven-plugin.version>3.3.1</spring-boot-maven-plugin.version>
+		<spring-boot-dependencies.version>3.3.3</spring-boot-dependencies.version>
+		<spring-boot-maven-plugin.version>3.3.3</spring-boot-maven-plugin.version>
 		<maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
 		<org.mapstruct.version>1.6.0.Beta1</org.mapstruct.version>
 		<private-api-sdk-java.version>4.0.4</private-api-sdk-java.version>
@@ -239,17 +239,17 @@
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
 
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>${maven-surefire-plugin.version}</version>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-checkstyle-plugin</artifactId>
-                <version>2.17</version>
-            </plugin>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<version>${maven-surefire-plugin.version}</version>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-checkstyle-plugin</artifactId>
+				<version>2.17</version>
+			</plugin>
 		</plugins>
 	</build>
 </project>

--- a/suppress.xml
+++ b/suppress.xml
@@ -1,10 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
-    <suppress until="2024-09-01Z">
+    <suppress until="2024-12-01Z">
         <notes><![CDATA[
-   file name: jackson-databind-2.15.2.jar
+   file name: spring-webmvc-6.1.10.jar
    ]]></notes>
-        <packageUrl regex="true">^pkg:maven/com\.fasterxml\.jackson\.core/jackson\-databind@.*$</packageUrl>
-        <cve>CVE-2023-35116</cve>
+        <cve>CVE-2024-38816</cve>
     </suppress>
 </suppressions>


### PR DESCRIPTION
Suppressing CVE-2024-38816 as currently latest spring boot starter does not support the spring framework dependency with the CVE fix

__Short description outlining key changes/additions__

__JIRA Ticket Number__

### Type of change

* [ ] Bug fix
* [ ] New feature
* [ ] Breaking change
* [ ] Infrastructure change

### Pull request checklist

* [ ] I have added unit tests for new code that I have added
* [ ] I have added/updated functional tests where appropriate
* [ ] The code follows our [coding standards](https://github.com/companieshouse/styleguides/blob/master/java.md)

__An exhaustive list of peer review checks can be read [here](https://github.com/companieshouse/styleguides/blob/master/java_review.md#developer-actions-prior-to-code-commitreview-started)__