### PR TITLE
Adding new business sector enum and updating auditors enum 

### DIFF
--- a/src/main/java/uk/gov/companieshouse/acsp/models/dto/AcspDataDto.java
+++ b/src/main/java/uk/gov/companieshouse/acsp/models/dto/AcspDataDto.java
@@ -2,6 +2,7 @@ package uk.gov.companieshouse.acsp.models.dto;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import uk.gov.companieshouse.acsp.models.enums.BusinessSector;
 import uk.gov.companieshouse.acsp.models.enums.RoleType;
 import uk.gov.companieshouse.acsp.models.enums.TypeOfBusiness;
 
@@ -23,7 +24,7 @@ public class AcspDataDto {
 
     private String businessName;
 
-    private String workSector;
+    private BusinessSector workSector;
 
     private AMLSupervisoryBodiesDto[] amlSupervisoryBodies;
 
@@ -95,11 +96,11 @@ public class AcspDataDto {
         this.businessName = businessName;
     }
 
-    public String getWorkSector() {
+    public BusinessSector getWorkSector() {
         return workSector;
     }
 
-    public void setWorkSector(String workSector) {
+    public void setWorkSector(BusinessSector workSector) {
         this.workSector = workSector;
     }
 

--- a/src/main/java/uk/gov/companieshouse/acsp/models/enums/BusinessSector.java
+++ b/src/main/java/uk/gov/companieshouse/acsp/models/enums/BusinessSector.java
@@ -1,14 +1,15 @@
 package uk.gov.companieshouse.acsp.models.enums;
 
 public enum BusinessSector {
-    AIA("auditors, insolvency-practitioners, external-accountants-and-tax-advisers"),
+    AIP("auditors, insolvency-practitioners, external-accountants-and-tax-advisers"),
     ILP("independent-legal-professionals"),
     TCSP("trust-or-company-service-providers"),
     CI("credit-institutions"),
     FI("financial-institutions"),
     EA("estate-agents"),
     HVD("high-value-dealers"),
-    CASINOS("casinos");
+    CASINOS("casinos"),
+    PNTS("prefer-not-to-say");
 
     public final String label;
 

--- a/src/main/java/uk/gov/companieshouse/acsp/service/FilingsService.java
+++ b/src/main/java/uk/gov/companieshouse/acsp/service/FilingsService.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Service;
 import uk.gov.companieshouse.acsp.exception.ServiceException;
 import uk.gov.companieshouse.acsp.exception.SubmissionNotLinkedToTransactionException;
 import uk.gov.companieshouse.acsp.models.dto.AcspDataDto;
+import uk.gov.companieshouse.acsp.models.enums.BusinessSector;
 import uk.gov.companieshouse.acsp.models.enums.TypeOfBusiness;
 import uk.gov.companieshouse.acsp.models.filing.Presenter;
 import uk.gov.companieshouse.acsp.models.filing.Aml;
@@ -157,7 +158,12 @@ public class FilingsService {
     if(acspDataDto.getCompanyDetails() != null || acspDataDto.getBusinessName() != null) {
       buildCompanyDetails(acspDataDto, data);
     }
-    data.put("business_sector", Optional.ofNullable(acspDataDto.getWorkSector()).map((String::toUpperCase)).orElse(null));
+
+    if(BusinessSector.PNTS.equals(acspDataDto.getWorkSector())) {
+      data.put("business_sector", null);
+    } else {
+      data.put("business_sector", Optional.ofNullable(acspDataDto.getWorkSector()).map((BusinessSector::name)).orElse(null));
+    }
 
     if(acspDataDto.getAmlSupervisoryBodies() != null) {
       data.put("aml", buildAml(acspDataDto));

--- a/src/test/java/uk/gov/companieshouse/acsp/mapper/EnumTranslatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/acsp/mapper/EnumTranslatorTest.java
@@ -62,8 +62,8 @@ import uk.gov.companieshouse.acsp.models.enums.TypeOfBusiness;
     }
     @Test
     void workSectorStringToEnum() {
-        String inputEnum = BusinessSector.AIA.label;
-        BusinessSector expected = BusinessSector.AIA;
+        String inputEnum = BusinessSector.AIP.label;
+        BusinessSector expected = BusinessSector.AIP;
         BusinessSector actual = enumTranslator.businessSectorStringToEnum(inputEnum);
 
         assertEquals(expected, actual);

--- a/src/test/java/uk/gov/companieshouse/acsp/service/FilingServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/acsp/service/FilingServiceTest.java
@@ -15,6 +15,7 @@ import uk.gov.companieshouse.acsp.models.dto.AcspDataSubmissionDto;
 import uk.gov.companieshouse.acsp.models.dto.AddressDto;
 import uk.gov.companieshouse.acsp.models.dto.ApplicantDetailsDto;
 import uk.gov.companieshouse.acsp.models.enums.AMLSupervisoryBodies;
+import uk.gov.companieshouse.acsp.models.enums.BusinessSector;
 import uk.gov.companieshouse.acsp.models.enums.TypeOfBusiness;
 import uk.gov.companieshouse.acsp.models.filing.Aml;
 import uk.gov.companieshouse.acsp.models.filing.Presenter;
@@ -452,7 +453,7 @@ class FilingServiceTest {
 
         setACSPDataDto();
         acspDataDto.setTypeOfBusiness(TypeOfBusiness.LC);
-        acspDataDto.setWorkSector("Work Sector");
+        acspDataDto.setWorkSector(BusinessSector.AIP);
         acspDataDto.getApplicantDetails().setMiddleName(MIDDLE_NAME);
         acspDataDto.setBusinessName("businessName");
 
@@ -468,7 +469,7 @@ class FilingServiceTest {
         Assertions.assertEquals(response.getData().get("acsp_type").toString().toUpperCase(),
                 TypeOfBusiness.LC.name().toUpperCase());
         Assertions.assertNotNull(response.getData().get("aml"));
-        Assertions.assertEquals("WORK SECTOR", response.getData().get("business_sector"));
+        Assertions.assertEquals(BusinessSector.AIP.toString(), response.getData().get("business_sector"));
         Assertions.assertEquals("CREDIT-CARD", response.getData().get("payment_method"));
         Assertions.assertEquals("PAYMENT_REFERENCE", response.getData().get("payment_reference"));
         Assertions.assertNull(response.getData().get("business_name"));
@@ -491,7 +492,7 @@ class FilingServiceTest {
         transaction.setStatus(TransactionStatus.CLOSED);
 
         setACSPDataDto();
-        acspDataDto.setWorkSector("Work Sector");
+        acspDataDto.setWorkSector(BusinessSector.ILP);
         acspDataDto.getApplicantDetails().setMiddleName(MIDDLE_NAME);
         LocalDate localDate = LocalDate.parse("1984-10-31");
         acspDataDto.getApplicantDetails().setDateOfBirth(localDate);
@@ -526,7 +527,7 @@ class FilingServiceTest {
         transaction.setStatus(TransactionStatus.CLOSED);
 
         setACSPDataDto();
-        acspDataDto.setWorkSector("Work Sector");
+        acspDataDto.setWorkSector(BusinessSector.TCSP);
         acspDataDto.getApplicantDetails().setMiddleName(MIDDLE_NAME);
         LocalDate localDate = LocalDate.parse("1984-10-31");
         acspDataDto.getApplicantDetails().setDateOfBirth(localDate);
@@ -563,7 +564,7 @@ class FilingServiceTest {
         transaction.setStatus(TransactionStatus.CLOSED);
 
         setACSPDataDto();
-        acspDataDto.setWorkSector("Work Sector");
+        acspDataDto.setWorkSector(BusinessSector.TCSP);
         acspDataDto.getApplicantDetails().setMiddleName(MIDDLE_NAME);
         acspDataDto.setBusinessName("businessName");
         LocalDate localDate = LocalDate.parse("1984-10-31");
@@ -603,7 +604,7 @@ class FilingServiceTest {
         transaction.setStatus(TransactionStatus.CLOSED);
 
         setACSPDataDto();
-        acspDataDto.setWorkSector("Work Sector");
+        acspDataDto.setWorkSector(BusinessSector.ILP);
         acspDataDto.getApplicantDetails().setMiddleName(MIDDLE_NAME);
         acspDataDto.setBusinessName("businessName");
         LocalDate localDate = LocalDate.parse("1984-10-31");
@@ -635,7 +636,7 @@ class FilingServiceTest {
         transaction.setStatus(TransactionStatus.CLOSED);
 
         setACSPDataDto();
-        acspDataDto.setWorkSector("Work Sector");
+        acspDataDto.setWorkSector(BusinessSector.HVD);
         acspDataDto.getApplicantDetails().setMiddleName(MIDDLE_NAME);
         acspDataDto.setBusinessName("businessName");
         LocalDate localDate = LocalDate.parse("1984-10-31");
@@ -662,7 +663,7 @@ class FilingServiceTest {
         transaction.setStatus(TransactionStatus.CLOSED);
 
         setACSPDataDto();
-        acspDataDto.setWorkSector("Work Sector");
+        acspDataDto.setWorkSector(BusinessSector.CASINOS);
         acspDataDto.getApplicantDetails().setMiddleName(MIDDLE_NAME);
         acspDataDto.setBusinessName("businessName");
         LocalDate localDate = LocalDate.parse("1984-10-31");
@@ -691,7 +692,7 @@ class FilingServiceTest {
         transaction.setStatus(TransactionStatus.CLOSED);
 
         setACSPDataDto();
-        acspDataDto.setWorkSector("Work Sector");
+        acspDataDto.setWorkSector(BusinessSector.PNTS);
         acspDataDto.getApplicantDetails().setMiddleName(MIDDLE_NAME);
         acspDataDto.setBusinessName("businessName");
         LocalDate localDate = LocalDate.parse("1984-10-31");
@@ -721,7 +722,7 @@ class FilingServiceTest {
         transaction.setStatus(TransactionStatus.CLOSED);
 
         setACSPDataDto();
-        acspDataDto.setWorkSector("Work Sector");
+        acspDataDto.setWorkSector(BusinessSector.CI);
         acspDataDto.getApplicantDetails().setMiddleName(MIDDLE_NAME);
         acspDataDto.getApplicantDetails().setFirstName(null);
         acspDataDto.getApplicantDetails().setLastName(null);
@@ -754,7 +755,7 @@ class FilingServiceTest {
         transaction.setStatus(TransactionStatus.CLOSED);
 
         setACSPDataDto();
-        acspDataDto.setWorkSector("Work Sector");
+        acspDataDto.setWorkSector(BusinessSector.AIP);
         acspDataDto.getApplicantDetails().setMiddleName(MIDDLE_NAME);
         acspDataDto.setBusinessName("businessName");
         LocalDate localDate = LocalDate.parse("1984-10-31");


### PR DESCRIPTION
__Short description outlining key changes/additions__

Includes changes against 2 tickets.

Ticket 1: IDVA5-1316

- Added new 'Prefer not to say' work sector option enum to match data sent from work sector front end page
- Updated AcspDataDto to use BusinessSector object 
- Updated buildAcspData method on FilingService to send null value if 'Prefer not to say' option is selected on work sector as we don't want this data to be sent to CHIPS when Transaction is processed

Ticket 2: IDVA5-1457

- Updated "Auditors, insolvency practitioners, external accountants and tax advisers" work sector enum to AIP to match CHIPS mapping
- Updated failing tests

__JIRA Ticket Number__

Includes changes made against tickets:

[IDVA5-1316](https://companieshouse.atlassian.net/browse/IDVA5-1316)
[IDVA5-1457](https://companieshouse.atlassian.net/browse/IDVA5-1457)

### Type of change

* [x] Bug fix
* [x] New feature
* [ ] Breaking change
* [ ] Infrastructure change

### Pull request checklist

* [x] I have added unit tests for new code that I have added
* [ ] I have added/updated functional tests where appropriate
* [x] The code follows our [coding standards](https://github.com/companieshouse/styleguides/blob/master/java.md)

__An exhaustive list of peer review checks can be read [here](https://github.com/companieshouse/styleguides/blob/master/java_review.md#developer-actions-prior-to-code-commitreview-started)__

[IDVA5-1316]: https://companieshouse.atlassian.net/browse/IDVA5-1316?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[IDVA5-1457]: https://companieshouse.atlassian.net/browse/IDVA5-1457?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ