### PR TITLE
Updating filing endpoint for update acsp service

### DIFF
--- a/src/main/java/uk/gov/companieshouse/acsp/models/dao/AcspDataDao.java
+++ b/src/main/java/uk/gov/companieshouse/acsp/models/dao/AcspDataDao.java
@@ -38,6 +38,9 @@ public class AcspDataDao {
     @Field("aml_supervisory_bodies")
     private AMLSupervisoryBodiesDao[] amlSupervisoryBodies;
 
+    @Field("removed_aml_supervisory_bodies")
+    private AMLSupervisoryBodiesDao[] removedAmlSupervisoryBodies;
+
     @Field("company_details")
     private CompanyDao companyDetails;
 
@@ -55,6 +58,9 @@ public class AcspDataDao {
 
     @JsonProperty("acsp_type")
     private String acspType;
+
+    @JsonProperty("acsp_id")
+    private String acspId;
 
     public String getId() {
         return id;
@@ -128,6 +134,14 @@ public class AcspDataDao {
         this.amlSupervisoryBodies = amlSupervisoryBodies;
     }
 
+    public AMLSupervisoryBodiesDao[] getRemovedAmlSupervisoryBodies() {
+        return removedAmlSupervisoryBodies;
+    }
+
+    public void setRemovedAmlSupervisoryBodies(AMLSupervisoryBodiesDao[] removedAmlSupervisoryBodies) {
+        this.removedAmlSupervisoryBodies = removedAmlSupervisoryBodies;
+    }
+
     public CompanyDao getCompanyDetails() {
         return companyDetails;
     }
@@ -173,5 +187,13 @@ public class AcspDataDao {
 
     public void setAcspType(String acspType) {
         this.acspType = acspType;
+    }
+
+    public String getAcspId() {
+        return acspId;
+    }
+
+    public void setAcspId(String acspId) {
+        this.acspId = acspId;
     }
 }

--- a/src/main/java/uk/gov/companieshouse/acsp/models/dto/AcspDataDto.java
+++ b/src/main/java/uk/gov/companieshouse/acsp/models/dto/AcspDataDto.java
@@ -29,6 +29,8 @@ public class AcspDataDto {
 
     private AMLSupervisoryBodiesDto[] amlSupervisoryBodies;
 
+    private AMLSupervisoryBodiesDto[] removedAmlSupervisoryBodies;
+
     private CompanyDto companyDetails;
 
     private boolean companyAuthCodeProvided;
@@ -40,6 +42,8 @@ public class AcspDataDto {
     private String howAreYouRegisteredWithAml;
 
     private AcspType acspType;
+
+    private String acspId;
 
     // Getters and Setters
 
@@ -115,6 +119,14 @@ public class AcspDataDto {
         this.amlSupervisoryBodies = amlSupervisoryBodies;
     }
 
+    public AMLSupervisoryBodiesDto[] getRemovedAmlSupervisoryBodies() {
+        return removedAmlSupervisoryBodies;
+    }
+
+    public void setRemovedAmlSupervisoryBodies(AMLSupervisoryBodiesDto[] removedAmlSupervisoryBodies) {
+        this.removedAmlSupervisoryBodies = removedAmlSupervisoryBodies;
+    }
+
     public CompanyDto getCompanyDetails() {
         return companyDetails;
     }
@@ -161,5 +173,13 @@ public class AcspDataDto {
 
     public void setAcspType(AcspType acspType) {
         this.acspType = acspType;
+    }
+
+    public String getAcspId() {
+        return acspId;
+    }
+
+    public void setAcspId(String acspId) {
+        this.acspId = acspId;
     }
 }

--- a/src/main/java/uk/gov/companieshouse/acsp/models/filing/Aml.java
+++ b/src/main/java/uk/gov/companieshouse/acsp/models/filing/Aml.java
@@ -8,6 +8,8 @@ public class Aml {
     private AmlMembership[] amlMemberships;
     @JsonProperty("person_name")
     private PersonName personName;
+    @JsonProperty("previous_aml_memberships")
+    private AmlMembership[] previousAmlMemberships;
 
     public AmlMembership[] getAmlMemberships() {
         return amlMemberships;
@@ -23,5 +25,11 @@ public class Aml {
 
     public void setPersonName(PersonName personName) {
         this.personName = personName;
+    }
+
+    public AmlMembership[] getPreviousAmlMemberships() { return previousAmlMemberships; }
+
+    public void setPreviousAmlMemberships(AmlMembership[] previousAmlMemberships) {
+        this.previousAmlMemberships = previousAmlMemberships;
     }
 }

--- a/src/main/java/uk/gov/companieshouse/acsp/service/FilingsService.java
+++ b/src/main/java/uk/gov/companieshouse/acsp/service/FilingsService.java
@@ -63,6 +63,10 @@ public class FilingsService {
 
   private static final String SUBMISSION = "submission";
 
+  private static final String REGISTERED_OFFICE_ADDRESS = "registered_office_address";
+
+  private static final String SERVICE_ADDRESS = "service_address";
+
   private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd-MM-yyyy");
 
   @Autowired
@@ -96,7 +100,7 @@ public class FilingsService {
     }
   }
 
-  private void buildFilingStatus(FilingApi filing, Boolean isRegistration) {
+  private void buildFilingStatus(FilingApi filing, boolean isRegistration) {
     filing.setKind(FILING_KIND_ACSP);
     if (isRegistration) {
       filing.setCost(costAmount);
@@ -127,7 +131,7 @@ public class FilingsService {
   }
 
   private Map<String, Object> buildData(AcspDataDto acspDataDto, String transactionId, Transaction transaction,
-                                            String passThroughTokenHeader, Boolean isRegistration) throws ServiceException {
+                                            String passThroughTokenHeader, boolean isRegistration) throws ServiceException {
     Map<String, Object> data = new HashMap<>();
     if (!isRegistration) {
       buildUpdateAcspData(data, acspDataDto);
@@ -148,12 +152,12 @@ public class FilingsService {
     if(TypeOfBusiness.LP.equals(acspDataDto.getTypeOfBusiness()) ||
             TypeOfBusiness.PARTNERSHIP.equals(acspDataDto.getTypeOfBusiness())||
             TypeOfBusiness.UNINCORPORATED.equals(acspDataDto.getTypeOfBusiness())) {
-      data.put("registered_office_address", buildRegisteredOfficeAddress(acspDataDto));
-      data.put("service_address",buildServiceAddress(acspDataDto));
+      data.put(REGISTERED_OFFICE_ADDRESS, buildRegisteredOfficeAddress(acspDataDto));
+      data.put(SERVICE_ADDRESS,buildServiceAddress(acspDataDto));
     } else if (TypeOfBusiness.SOLE_TRADER.equals(acspDataDto.getTypeOfBusiness())) {
-      data.put("registered_office_address", buildCorrespondenAddress(acspDataDto));
+      data.put(REGISTERED_OFFICE_ADDRESS, buildCorrespondenAddress(acspDataDto));
     } else {
-      data.put("service_address",buildServiceAddress(acspDataDto));
+      data.put(SERVICE_ADDRESS,buildServiceAddress(acspDataDto));
     }
 
     if(transaction.getStatus() != null &&
@@ -195,11 +199,11 @@ public class FilingsService {
     data.put("acsp_details", buildUpdateAmlDetails(acspDataDto));
 
     if(acspDataDto.getRegisteredOfficeAddress() != null) {
-      data.put("registered_office_address", buildRegisteredOfficeAddress(acspDataDto));
+      data.put(REGISTERED_OFFICE_ADDRESS, buildRegisteredOfficeAddress(acspDataDto));
     }
 
     if(acspDataDto.getApplicantDetails() != null && acspDataDto.getApplicantDetails().getCorrespondenceAddress() != null) {
-      data.put("service_address", buildServiceAddress(acspDataDto));
+      data.put(SERVICE_ADDRESS, buildServiceAddress(acspDataDto));
     }
 
     if(acspDataDto.getTypeOfBusiness() != null &&

--- a/src/main/java/uk/gov/companieshouse/acsp/service/FilingsService.java
+++ b/src/main/java/uk/gov/companieshouse/acsp/service/FilingsService.java
@@ -202,7 +202,7 @@ public class FilingsService {
       data.put(REGISTERED_OFFICE_ADDRESS, buildRegisteredOfficeAddress(acspDataDto));
     }
 
-    if(acspDataDto.getApplicantDetails() != null && acspDataDto.getApplicantDetails().getCorrespondenceAddress() != null) {
+    if(acspDataDto.getApplicantDetails().getCorrespondenceAddress() != null) {
       data.put(SERVICE_ADDRESS, buildServiceAddress(acspDataDto));
     }
 

--- a/src/test/java/uk/gov/companieshouse/acsp/service/FilingServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/acsp/service/FilingServiceTest.java
@@ -15,12 +15,14 @@ import uk.gov.companieshouse.acsp.models.dto.AcspDataSubmissionDto;
 import uk.gov.companieshouse.acsp.models.dto.AddressDto;
 import uk.gov.companieshouse.acsp.models.dto.ApplicantDetailsDto;
 import uk.gov.companieshouse.acsp.models.enums.AMLSupervisoryBodies;
+import uk.gov.companieshouse.acsp.models.enums.AcspType;
 import uk.gov.companieshouse.acsp.models.enums.BusinessSector;
 import uk.gov.companieshouse.acsp.models.enums.TypeOfBusiness;
 import uk.gov.companieshouse.acsp.models.filing.Aml;
 import uk.gov.companieshouse.acsp.models.filing.Presenter;
 import uk.gov.companieshouse.acsp.models.filing.STPersonalInformation;
 import uk.gov.companieshouse.acsp.models.filing.ServiceAddress;
+import uk.gov.companieshouse.acsp.models.filing.PersonName;
 import uk.gov.companieshouse.acsp.sdk.ApiClientService;
 import uk.gov.companieshouse.api.ApiClient;
 import uk.gov.companieshouse.api.error.ApiErrorResponseException;
@@ -56,6 +58,7 @@ class FilingServiceTest {
     private static final String PAYMENT_METHOD = "credit-card";
     private static final String PAYMENT_REFERENCE = "PAYMENT_REFERENCE";
     private static final String COUNTRY_OF_RESIDENCE = "United Kingdom";
+    private static final String EMAIL_ADDRESS = "testEmail@email.com";
 
     private static final String TRANSACTION_ID = "3324324324-3243243-32424";
 
@@ -140,6 +143,7 @@ class FilingServiceTest {
         setACSPDataDto();
         CompanyDto companyDto = new CompanyDto();
         acspDataDto.setCompanyDetails(companyDto);
+        acspDataDto.setAcspType(AcspType.REGISTER_ACSP);
     }
 
     private void setACSPDataDtoWithoutNamesandId() {
@@ -235,6 +239,7 @@ class FilingServiceTest {
         initGetPaymentMocks();
 
         setACSPDataDto();
+        acspDataDto.setAcspType(AcspType.REGISTER_ACSP);
         when(acspService.getAcsp(any(), any())).thenReturn(Optional.of(acspDataDto));
         when(transactionService.getTransaction(PASS_THROUGH_HEADER, TRANSACTION_ID)).thenReturn(transaction);
 
@@ -259,6 +264,7 @@ class FilingServiceTest {
         initGetPaymentMocks();
 
         setACSPDataDtoWithoutApplicantDetails();
+        acspDataDto.setAcspType(AcspType.REGISTER_ACSP);
         when(acspService.getAcsp(any(), any())).thenReturn(Optional.of(acspDataDto));
         when(transactionService.getTransaction(PASS_THROUGH_HEADER, TRANSACTION_ID)).thenReturn(transaction);
 
@@ -280,6 +286,7 @@ class FilingServiceTest {
         initGetPaymentMocks();
 
         setACSPDataDto();
+        acspDataDto.setAcspType(AcspType.REGISTER_ACSP);
         acspDataDto.getApplicantDetails().setCorrespondenceAddress(null);
         acspDataDto.setRegisteredOfficeAddress(buildBusinessAddress());
         when(acspService.getAcsp(any(), any())).thenReturn(Optional.of(acspDataDto));
@@ -306,6 +313,7 @@ class FilingServiceTest {
         initGetPaymentMocks();
 
         setACSPDataDto();
+        acspDataDto.setAcspType(AcspType.REGISTER_ACSP);
         acspDataDto.getApplicantDetails().setCorrespondenceAddress(buildCorrespondenceAddressWithOnlyCountry());
         acspDataDto.setRegisteredOfficeAddress(buildBusinessAddress());
         when(acspService.getAcsp(any(), any())).thenReturn(Optional.of(acspDataDto));
@@ -331,6 +339,7 @@ class FilingServiceTest {
         initGetPaymentMocks();
 
         setACSPDataDto();
+        acspDataDto.setAcspType(AcspType.REGISTER_ACSP);
         acspDataDto.getApplicantDetails().setCorrespondenceAddress(buildBlankCorrespondenceAddress());
         acspDataDto.setRegisteredOfficeAddress(buildBlankBusinessAddress());
         when(acspService.getAcsp(any(), any())).thenReturn(Optional.of(acspDataDto));
@@ -356,6 +365,7 @@ class FilingServiceTest {
         initGetPaymentMocks();
 
         setACSPDataDtoWithCompanyDetails();
+        acspDataDto.setAcspType(AcspType.REGISTER_ACSP);
         acspDataDto.setTypeOfBusiness(TypeOfBusiness.LC);
         acspDataDto.getApplicantDetails().setCorrespondenceAddress(buildBlankCorrespondenceAddress());
         acspDataDto.setRegisteredOfficeAddress(buildBlankBusinessAddress());
@@ -383,6 +393,7 @@ class FilingServiceTest {
         initGetPaymentMocks();
 
         setACSPDataDtoWithCompanyDetails();
+        acspDataDto.setAcspType(AcspType.REGISTER_ACSP);
         acspDataDto.setTypeOfBusiness(TypeOfBusiness.CORPORATE_BODY);
         acspDataDto.getApplicantDetails().setCorrespondenceAddress(buildBlankCorrespondenceAddress());
         acspDataDto.setRegisteredOfficeAddress(buildBlankBusinessAddress());
@@ -410,6 +421,7 @@ class FilingServiceTest {
         initGetPaymentMocks();
 
         setACSPDataDtoWithoutNamesandId();
+        acspDataDto.setAcspType(AcspType.REGISTER_ACSP);
         acspDataDto.getApplicantDetails().setCorrespondenceAddress(buildBlankCorrespondenceAddress());
         acspDataDto.setRegisteredOfficeAddress(buildBlankBusinessAddress());
         when(acspService.getAcsp(any(), any())).thenReturn(Optional.of(acspDataDto));
@@ -456,6 +468,7 @@ class FilingServiceTest {
         acspDataDto.setWorkSector(BusinessSector.AIP);
         acspDataDto.getApplicantDetails().setMiddleName(MIDDLE_NAME);
         acspDataDto.setBusinessName("businessName");
+        acspDataDto.setAcspType(AcspType.REGISTER_ACSP);
 
         AMLSupervisoryBodiesDto amlSupervisoryBodies1 = new AMLSupervisoryBodiesDto();
         amlSupervisoryBodies1.setAmlSupervisoryBody(AMLSupervisoryBodies.HMRC);
@@ -496,6 +509,7 @@ class FilingServiceTest {
         acspDataDto.getApplicantDetails().setMiddleName(MIDDLE_NAME);
         LocalDate localDate = LocalDate.parse("1984-10-31");
         acspDataDto.getApplicantDetails().setDateOfBirth(localDate);
+        acspDataDto.setAcspType(AcspType.REGISTER_ACSP);
 
         AMLSupervisoryBodiesDto amlSupervisoryBodies1 = new AMLSupervisoryBodiesDto();
         amlSupervisoryBodies1.setAmlSupervisoryBody(AMLSupervisoryBodies.HMRC);
@@ -527,6 +541,7 @@ class FilingServiceTest {
         transaction.setStatus(TransactionStatus.CLOSED);
 
         setACSPDataDto();
+        acspDataDto.setAcspType(AcspType.REGISTER_ACSP);
         acspDataDto.setWorkSector(BusinessSector.TCSP);
         acspDataDto.getApplicantDetails().setMiddleName(MIDDLE_NAME);
         LocalDate localDate = LocalDate.parse("1984-10-31");
@@ -564,6 +579,7 @@ class FilingServiceTest {
         transaction.setStatus(TransactionStatus.CLOSED);
 
         setACSPDataDto();
+        acspDataDto.setAcspType(AcspType.REGISTER_ACSP);
         acspDataDto.setWorkSector(BusinessSector.TCSP);
         acspDataDto.getApplicantDetails().setMiddleName(MIDDLE_NAME);
         acspDataDto.setBusinessName("businessName");
@@ -604,6 +620,7 @@ class FilingServiceTest {
         transaction.setStatus(TransactionStatus.CLOSED);
 
         setACSPDataDto();
+        acspDataDto.setAcspType(AcspType.REGISTER_ACSP);
         acspDataDto.setWorkSector(BusinessSector.ILP);
         acspDataDto.getApplicantDetails().setMiddleName(MIDDLE_NAME);
         acspDataDto.setBusinessName("businessName");
@@ -636,6 +653,7 @@ class FilingServiceTest {
         transaction.setStatus(TransactionStatus.CLOSED);
 
         setACSPDataDto();
+        acspDataDto.setAcspType(AcspType.REGISTER_ACSP);
         acspDataDto.setWorkSector(BusinessSector.HVD);
         acspDataDto.getApplicantDetails().setMiddleName(MIDDLE_NAME);
         acspDataDto.setBusinessName("businessName");
@@ -663,6 +681,7 @@ class FilingServiceTest {
         transaction.setStatus(TransactionStatus.CLOSED);
 
         setACSPDataDto();
+        acspDataDto.setAcspType(AcspType.REGISTER_ACSP);
         acspDataDto.setWorkSector(BusinessSector.CASINOS);
         acspDataDto.getApplicantDetails().setMiddleName(MIDDLE_NAME);
         acspDataDto.setBusinessName("businessName");
@@ -692,6 +711,7 @@ class FilingServiceTest {
         transaction.setStatus(TransactionStatus.CLOSED);
 
         setACSPDataDto();
+        acspDataDto.setAcspType(AcspType.REGISTER_ACSP);
         acspDataDto.setWorkSector(BusinessSector.PNTS);
         acspDataDto.getApplicantDetails().setMiddleName(MIDDLE_NAME);
         acspDataDto.setBusinessName("businessName");
@@ -722,6 +742,7 @@ class FilingServiceTest {
         transaction.setStatus(TransactionStatus.CLOSED);
 
         setACSPDataDto();
+        acspDataDto.setAcspType(AcspType.REGISTER_ACSP);
         acspDataDto.setWorkSector(BusinessSector.CI);
         acspDataDto.getApplicantDetails().setMiddleName(MIDDLE_NAME);
         acspDataDto.getApplicantDetails().setFirstName(null);
@@ -755,6 +776,7 @@ class FilingServiceTest {
         transaction.setStatus(TransactionStatus.CLOSED);
 
         setACSPDataDto();
+        acspDataDto.setAcspType(AcspType.REGISTER_ACSP);
         acspDataDto.setWorkSector(BusinessSector.AIP);
         acspDataDto.getApplicantDetails().setMiddleName(MIDDLE_NAME);
         acspDataDto.setBusinessName("businessName");
@@ -786,10 +808,206 @@ class FilingServiceTest {
         transaction.setClosedAt("2024-07-01T12:53Z");
 
         setACSPDataDto();
+        acspDataDto.setAcspType(AcspType.REGISTER_ACSP);
         when(acspService.getAcsp(any(), any())).thenReturn(Optional.of(acspDataDto));
         when(transactionService.getTransaction(PASS_THROUGH_HEADER, TRANSACTION_ID)).thenReturn(transaction);
         var response = filingsService.generateAcspApplicationFiling(ACSP_ID, TRANSACTION_ID, PASS_THROUGH_HEADER);
         Assertions.assertTrue(response.getDescription().contains("01-07-2024"));
 
+    }
+
+    @Test
+    void testGenerateAcspApplicationFilingUpdateAcsp() throws Exception {
+        setACSPDataDto();
+        acspDataDto.setAcspType(AcspType.UPDATE_ACSP);
+        when(acspService.getAcsp(any(), any())).thenReturn(Optional.of(acspDataDto));
+        when(transactionService.getTransaction(PASS_THROUGH_HEADER, TRANSACTION_ID)).thenReturn(transaction);
+
+        var response = filingsService.generateAcspApplicationFiling(ACSP_ID, TRANSACTION_ID, PASS_THROUGH_HEADER);
+        Assertions.assertNull(response.getCost());
+        Assertions.assertNotNull(response.getData());
+        Assertions.assertNull(response.getData().get("payment_reference"));
+        Assertions.assertNull(response.getData().get("payment_method"));
+        Assertions.assertNotNull(response.getData().get("presenter"));
+        Assertions.assertEquals(FIRST_NAME.toUpperCase(), ((Presenter) response.getData().get("presenter")).getFirstName());
+        Assertions.assertEquals(LAST_NAME.toUpperCase(), ((Presenter) response.getData().get("presenter")).getLastName());
+        Assertions.assertNotNull(response.getData().get("submission"));
+        Assertions.assertEquals("acsp", response.getKind());
+    }
+
+    @Test
+    void testGenerateAllDataUpdateLimitedAcsp() throws Exception {
+        setACSPDataDto();
+        acspDataDto.setAcspType(AcspType.UPDATE_ACSP);
+        acspDataDto.setAcspId(ACSP_ID);
+        acspDataDto.getApplicantDetails().setCorrespondenceEmail(EMAIL_ADDRESS);
+        acspDataDto.setBusinessName("Test Limited Company Name Update ACSP");
+        acspDataDto.setRegisteredOfficeAddress(buildBusinessAddress());
+        acspDataDto.getApplicantDetails().setCorrespondenceAddress(buildCorrespondenceAddress());
+        acspDataDto.setTypeOfBusiness(TypeOfBusiness.LC);
+
+        AMLSupervisoryBodiesDto amlSupervisoryBodies1 = new AMLSupervisoryBodiesDto();
+        amlSupervisoryBodies1.setAmlSupervisoryBody(AMLSupervisoryBodies.HMRC);
+        amlSupervisoryBodies1.setMembershipId("12345678");
+        AMLSupervisoryBodiesDto[] amlSupervisoryBodies = new AMLSupervisoryBodiesDto[]{amlSupervisoryBodies1};
+        acspDataDto.setAmlSupervisoryBodies(amlSupervisoryBodies);
+
+        AMLSupervisoryBodiesDto amlSupervisoryBodies2 = new AMLSupervisoryBodiesDto();
+        amlSupervisoryBodies2.setAmlSupervisoryBody(AMLSupervisoryBodies.FCA);
+        amlSupervisoryBodies2.setMembershipId("87654321");
+        AMLSupervisoryBodiesDto[] removedAmlSupervisoryBodies = new AMLSupervisoryBodiesDto[]{amlSupervisoryBodies2};
+        acspDataDto.setRemovedAmlSupervisoryBodies(removedAmlSupervisoryBodies);
+
+        when(acspService.getAcsp(any(), any())).thenReturn(Optional.of(acspDataDto));
+        when(transactionService.getTransaction(PASS_THROUGH_HEADER, TRANSACTION_ID)).thenReturn(transaction);
+
+        var response = filingsService.generateAcspApplicationFiling(ACSP_ID, TRANSACTION_ID, PASS_THROUGH_HEADER);
+
+        Assertions.assertNotNull(response.getData());
+        Assertions.assertEquals(ACSP_ID.toUpperCase(), response.getData().get("incorporation_number"));
+        Assertions.assertEquals(EMAIL_ADDRESS.toUpperCase(), response.getData().get("email"));
+        Assertions.assertEquals("Test Limited Company Name Update ACSP".toUpperCase(), response.getData().get("proposed_corporate_body_name"));
+        Assertions.assertNotNull(response.getData().get("acsp_details"));
+        Assertions.assertNotNull(response.getData().get("registered_office_address"));
+        Assertions.assertNotNull(response.getData().get("service_address"));
+        Assertions.assertNull(response.getData().get("st_personal_information"));
+
+        Aml acspDetails = (Aml) response.getData().get("acsp_details");
+        Assertions.assertNotNull(acspDetails.getAmlMemberships());
+        Assertions.assertEquals(1, acspDetails.getAmlMemberships().length);
+        Arrays.stream(acspDetails.getAmlMemberships()).forEach(
+                amlMembership -> {
+                    Assertions.assertEquals("12345678", amlMembership.getRegistrationNumber());
+                    Assertions.assertEquals(AMLSupervisoryBodies.HMRC.name(), amlMembership.getSupervisoryBody().toUpperCase());
+                }
+        );
+
+        Assertions.assertNotNull(acspDetails.getPreviousAmlMemberships());
+        Assertions.assertEquals(1, acspDetails.getPreviousAmlMemberships().length);
+        Arrays.stream(acspDetails.getPreviousAmlMemberships()).forEach(
+                amlMembership -> {
+                    Assertions.assertEquals("87654321", amlMembership.getRegistrationNumber());
+                    Assertions.assertEquals(AMLSupervisoryBodies.FCA.name(), amlMembership.getSupervisoryBody().toUpperCase());
+                }
+        );
+    }
+
+    @Test
+    void testGenerateAllDataUpdateSoleTraderAcsp() throws Exception {
+        setACSPDataDto();
+        acspDataDto.setAcspType(AcspType.UPDATE_ACSP);
+        acspDataDto.setAcspId(ACSP_ID);
+        acspDataDto.getApplicantDetails().setCorrespondenceEmail(EMAIL_ADDRESS);
+        acspDataDto.setBusinessName("Test Sole Trader Business Name Update ACSP");
+        acspDataDto.setRegisteredOfficeAddress(buildBusinessAddress());
+        acspDataDto.getApplicantDetails().setCorrespondenceAddress(buildCorrespondenceAddress());
+        acspDataDto.setTypeOfBusiness(TypeOfBusiness.SOLE_TRADER);
+        acspDataDto.getApplicantDetails().setFirstName(FIRST_NAME);
+        acspDataDto.getApplicantDetails().setMiddleName(MIDDLE_NAME);
+        acspDataDto.getApplicantDetails().setLastName(LAST_NAME);
+
+        AMLSupervisoryBodiesDto amlSupervisoryBodies1 = new AMLSupervisoryBodiesDto();
+        amlSupervisoryBodies1.setAmlSupervisoryBody(AMLSupervisoryBodies.AAT);
+        amlSupervisoryBodies1.setMembershipId("12345678");
+        AMLSupervisoryBodiesDto[] amlSupervisoryBodies = new AMLSupervisoryBodiesDto[]{amlSupervisoryBodies1};
+        acspDataDto.setAmlSupervisoryBodies(amlSupervisoryBodies);
+
+        AMLSupervisoryBodiesDto amlSupervisoryBodies2 = new AMLSupervisoryBodiesDto();
+        amlSupervisoryBodies2.setAmlSupervisoryBody(AMLSupervisoryBodies.AIA);
+        amlSupervisoryBodies2.setMembershipId("87654321");
+        AMLSupervisoryBodiesDto[] removedAmlSupervisoryBodies = new AMLSupervisoryBodiesDto[]{amlSupervisoryBodies2};
+        acspDataDto.setRemovedAmlSupervisoryBodies(removedAmlSupervisoryBodies);
+
+        when(acspService.getAcsp(any(), any())).thenReturn(Optional.of(acspDataDto));
+        when(transactionService.getTransaction(PASS_THROUGH_HEADER, TRANSACTION_ID)).thenReturn(transaction);
+
+        var response = filingsService.generateAcspApplicationFiling(ACSP_ID, TRANSACTION_ID, PASS_THROUGH_HEADER);
+
+        Assertions.assertNotNull(response.getData());
+        Assertions.assertEquals(ACSP_ID.toUpperCase(), response.getData().get("incorporation_number"));
+        Assertions.assertEquals(EMAIL_ADDRESS.toUpperCase(), response.getData().get("email"));
+        Assertions.assertEquals("Test Sole Trader Business Name Update ACSP".toUpperCase(), response.getData().get("proposed_corporate_body_name"));
+        Assertions.assertNotNull(response.getData().get("acsp_details"));
+        Assertions.assertNotNull(response.getData().get("registered_office_address"));
+        Assertions.assertNotNull(response.getData().get("service_address"));
+        Assertions.assertNotNull(response.getData().get("st_personal_information"));
+
+
+        Aml acspDetails = (Aml) response.getData().get("acsp_details");
+        Assertions.assertNotNull(acspDetails.getAmlMemberships());
+        Assertions.assertEquals(1, acspDetails.getAmlMemberships().length);
+        Arrays.stream(acspDetails.getAmlMemberships()).forEach(
+                amlMembership -> {
+                    Assertions.assertEquals("12345678", amlMembership.getRegistrationNumber());
+                    Assertions.assertEquals(AMLSupervisoryBodies.AAT.name(), amlMembership.getSupervisoryBody().toUpperCase());
+                }
+        );
+        Assertions.assertNotNull(acspDetails.getPreviousAmlMemberships());
+        Assertions.assertEquals(1, acspDetails.getPreviousAmlMemberships().length);
+        Arrays.stream(acspDetails.getPreviousAmlMemberships()).forEach(
+                amlMembership -> {
+                    Assertions.assertEquals("87654321", amlMembership.getRegistrationNumber());
+                    Assertions.assertEquals(AMLSupervisoryBodies.AIA.name(), amlMembership.getSupervisoryBody().toUpperCase());
+                }
+        );
+
+        PersonName personName = acspDetails.getPersonName();
+        Assertions.assertNotNull(personName);
+        Assertions.assertEquals(FIRST_NAME.toUpperCase(), personName.getFirstName());
+        Assertions.assertEquals(MIDDLE_NAME.toUpperCase(), personName.getMiddleName());
+        Assertions.assertEquals(LAST_NAME.toUpperCase(), personName.getLastName());
+    }
+
+    @Test
+    void testBuildUpdateAcspDataWithNonNullData() throws Exception {
+        setACSPDataDto();
+        acspDataDto.setAcspType(AcspType.UPDATE_ACSP);
+        acspDataDto.setAcspId(ACSP_ID);
+        acspDataDto.getApplicantDetails().setCorrespondenceEmail(EMAIL_ADDRESS);
+        acspDataDto.setBusinessName("Test Business Name Update ACSP");
+        acspDataDto.setRegisteredOfficeAddress(buildBusinessAddress());
+        acspDataDto.getApplicantDetails().setCorrespondenceAddress(buildCorrespondenceAddress());
+        acspDataDto.setTypeOfBusiness(TypeOfBusiness.SOLE_TRADER);
+
+        when(acspService.getAcsp(any(), any())).thenReturn(Optional.of(acspDataDto));
+        when(transactionService.getTransaction(PASS_THROUGH_HEADER, TRANSACTION_ID)).thenReturn(transaction);
+
+        var response = filingsService.generateAcspApplicationFiling(ACSP_ID, TRANSACTION_ID, PASS_THROUGH_HEADER);
+
+        Assertions.assertNotNull(response.getData());
+        Assertions.assertEquals(ACSP_ID.toUpperCase(), response.getData().get("incorporation_number"));
+        Assertions.assertEquals(EMAIL_ADDRESS.toUpperCase(), response.getData().get("email"));
+        Assertions.assertEquals("Test Business Name Update ACSP".toUpperCase(), response.getData().get("proposed_corporate_body_name"));
+        Assertions.assertNotNull(response.getData().get("acsp_details"));
+        Assertions.assertNotNull(response.getData().get("registered_office_address"));
+        Assertions.assertNotNull(response.getData().get("service_address"));
+        Assertions.assertNotNull(response.getData().get("st_personal_information"));
+    }
+
+    @Test
+    void testBuildUpdateAcspDataWithNullValues() throws Exception {
+        setACSPDataDto();
+        acspDataDto.setAcspType(AcspType.UPDATE_ACSP);
+        acspDataDto.setAcspId(ACSP_ID);
+        acspDataDto.getApplicantDetails().setCorrespondenceEmail(null);
+        acspDataDto.setBusinessName(null);
+        acspDataDto.setRegisteredOfficeAddress(null);
+        acspDataDto.getApplicantDetails().setCorrespondenceAddress(null);
+        acspDataDto.setTypeOfBusiness(null);
+
+        when(acspService.getAcsp(any(), any())).thenReturn(Optional.of(acspDataDto));
+        when(transactionService.getTransaction(PASS_THROUGH_HEADER, TRANSACTION_ID)).thenReturn(transaction);
+
+        var response = filingsService.generateAcspApplicationFiling(ACSP_ID, TRANSACTION_ID, PASS_THROUGH_HEADER);
+
+        Assertions.assertNotNull(response.getData());
+        Assertions.assertNotNull(response.getData().get("incorporation_number"));
+        Assertions.assertEquals(ACSP_ID.toUpperCase(), response.getData().get("incorporation_number"));
+        Assertions.assertNull(response.getData().get("email"));
+        Assertions.assertNull(response.getData().get("proposed_corporate_body_name"));
+        Assertions.assertNotNull(response.getData().get("acsp_details"));
+        Assertions.assertNull(response.getData().get("registered_office_address"));
+        Assertions.assertNull(response.getData().get("service_address"));
+        Assertions.assertNull(response.getData().get("st_personal_information"));
     }
 }

--- a/src/test/java/uk/gov/companieshouse/acsp/service/FilingServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/acsp/service/FilingServiceTest.java
@@ -950,63 +950,6 @@ class FilingServiceTest {
     }
 
     @Test
-    void testGenerateAllDataUpdateCorporateBodyAcspWithNullCorrespondenceAddress() throws Exception {
-        setACSPDataDto();
-        acspDataDto.setAcspType(AcspType.UPDATE_ACSP);
-        acspDataDto.setAcspId(ACSP_ID);
-        acspDataDto.getApplicantDetails().setCorrespondenceEmail(EMAIL_ADDRESS);
-        acspDataDto.setBusinessName("Test Corporate Body Name Update ACSP");
-        acspDataDto.setRegisteredOfficeAddress(buildBusinessAddress());
-        acspDataDto.getApplicantDetails().setCorrespondenceAddress(null); // Set CorrespondenceAddress to null
-        acspDataDto.setTypeOfBusiness(TypeOfBusiness.CORPORATE_BODY);
-
-        AMLSupervisoryBodiesDto amlSupervisoryBodies1 = new AMLSupervisoryBodiesDto();
-        amlSupervisoryBodies1.setAmlSupervisoryBody(AMLSupervisoryBodies.HMRC);
-        amlSupervisoryBodies1.setMembershipId("12345678");
-        AMLSupervisoryBodiesDto[] amlSupervisoryBodies = new AMLSupervisoryBodiesDto[]{amlSupervisoryBodies1};
-        acspDataDto.setAmlSupervisoryBodies(amlSupervisoryBodies);
-
-        AMLSupervisoryBodiesDto amlSupervisoryBodies2 = new AMLSupervisoryBodiesDto();
-        amlSupervisoryBodies2.setAmlSupervisoryBody(AMLSupervisoryBodies.FCA);
-        amlSupervisoryBodies2.setMembershipId("87654321");
-        AMLSupervisoryBodiesDto[] removedAmlSupervisoryBodies = new AMLSupervisoryBodiesDto[]{amlSupervisoryBodies2};
-        acspDataDto.setRemovedAmlSupervisoryBodies(removedAmlSupervisoryBodies);
-
-        when(acspService.getAcsp(any(), any())).thenReturn(Optional.of(acspDataDto));
-        when(transactionService.getTransaction(PASS_THROUGH_HEADER, TRANSACTION_ID)).thenReturn(transaction);
-
-        var response = filingsService.generateAcspApplicationFiling(ACSP_ID, TRANSACTION_ID, PASS_THROUGH_HEADER);
-
-        Assertions.assertNotNull(response.getData());
-        Assertions.assertEquals(ACSP_ID.toUpperCase(), response.getData().get("incorporation_number"));
-        Assertions.assertEquals(EMAIL_ADDRESS.toUpperCase(), response.getData().get("email"));
-        Assertions.assertEquals("Test Corporate Body Name Update ACSP".toUpperCase(), response.getData().get("proposed_corporate_body_name"));
-        Assertions.assertNotNull(response.getData().get("acsp_details"));
-        Assertions.assertNotNull(response.getData().get("registered_office_address"));
-        Assertions.assertNull(response.getData().get("service_address")); // Ensure service_address is null
-        Assertions.assertNull(response.getData().get("st_personal_information"));
-
-        Aml acspDetails = (Aml) response.getData().get("acsp_details");
-        Assertions.assertNotNull(acspDetails.getAmlMemberships());
-        Assertions.assertEquals(1, acspDetails.getAmlMemberships().length);
-        Arrays.stream(acspDetails.getAmlMemberships()).forEach(
-                amlMembership -> {
-                    Assertions.assertEquals("12345678", amlMembership.getRegistrationNumber());
-                    Assertions.assertEquals(AMLSupervisoryBodies.HMRC.name(), amlMembership.getSupervisoryBody().toUpperCase());
-                }
-        );
-
-        Assertions.assertNotNull(acspDetails.getPreviousAmlMemberships());
-        Assertions.assertEquals(1, acspDetails.getPreviousAmlMemberships().length);
-        Arrays.stream(acspDetails.getPreviousAmlMemberships()).forEach(
-                amlMembership -> {
-                    Assertions.assertEquals("87654321", amlMembership.getRegistrationNumber());
-                    Assertions.assertEquals(AMLSupervisoryBodies.FCA.name(), amlMembership.getSupervisoryBody().toUpperCase());
-                }
-        );
-    }
-
-    @Test
     void testGenerateAllDataUpdateSoleTraderAcsp() throws Exception {
         setACSPDataDto();
         acspDataDto.setAcspType(AcspType.UPDATE_ACSP);
@@ -1070,6 +1013,32 @@ class FilingServiceTest {
         Assertions.assertEquals(FIRST_NAME.toUpperCase(), personName.getFirstName());
         Assertions.assertEquals(MIDDLE_NAME.toUpperCase(), personName.getMiddleName());
         Assertions.assertEquals(LAST_NAME.toUpperCase(), personName.getLastName());
+    }
+
+    @Test
+    void testGenerateUpdateCorporateBodyAcspWithNullCorrespondenceAddress() throws Exception {
+        setACSPDataDto();
+        acspDataDto.setAcspType(AcspType.UPDATE_ACSP);
+        acspDataDto.setAcspId(ACSP_ID);
+        acspDataDto.getApplicantDetails().setCorrespondenceEmail(EMAIL_ADDRESS);
+        acspDataDto.setBusinessName("Test Corporate Body Name Update ACSP");
+        acspDataDto.setRegisteredOfficeAddress(buildBusinessAddress());
+        acspDataDto.getApplicantDetails().setCorrespondenceAddress(null);
+        acspDataDto.setTypeOfBusiness(TypeOfBusiness.CORPORATE_BODY);
+
+        when(acspService.getAcsp(any(), any())).thenReturn(Optional.of(acspDataDto));
+        when(transactionService.getTransaction(PASS_THROUGH_HEADER, TRANSACTION_ID)).thenReturn(transaction);
+
+        var response = filingsService.generateAcspApplicationFiling(ACSP_ID, TRANSACTION_ID, PASS_THROUGH_HEADER);
+
+        Assertions.assertNotNull(response.getData());
+        Assertions.assertEquals(ACSP_ID.toUpperCase(), response.getData().get("incorporation_number"));
+        Assertions.assertEquals(EMAIL_ADDRESS.toUpperCase(), response.getData().get("email"));
+        Assertions.assertEquals("Test Corporate Body Name Update ACSP".toUpperCase(), response.getData().get("proposed_corporate_body_name"));
+        Assertions.assertNotNull(response.getData().get("acsp_details"));
+        Assertions.assertNotNull(response.getData().get("registered_office_address"));
+        Assertions.assertNull(response.getData().get("service_address"));
+        Assertions.assertNull(response.getData().get("st_personal_information"));
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/acsp/service/FilingServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/acsp/service/FilingServiceTest.java
@@ -893,6 +893,120 @@ class FilingServiceTest {
     }
 
     @Test
+    void testGenerateAllDataUpdateLLPAcsp() throws Exception {
+        setACSPDataDto();
+        acspDataDto.setAcspType(AcspType.UPDATE_ACSP);
+        acspDataDto.setAcspId(ACSP_ID);
+        acspDataDto.getApplicantDetails().setCorrespondenceEmail(EMAIL_ADDRESS);
+        acspDataDto.setBusinessName("Test LLP Company Name Update ACSP");
+        acspDataDto.setRegisteredOfficeAddress(buildBusinessAddress());
+        acspDataDto.getApplicantDetails().setCorrespondenceAddress(buildCorrespondenceAddress());
+        acspDataDto.setTypeOfBusiness(TypeOfBusiness.LLP);
+
+        AMLSupervisoryBodiesDto amlSupervisoryBodies1 = new AMLSupervisoryBodiesDto();
+        amlSupervisoryBodies1.setAmlSupervisoryBody(AMLSupervisoryBodies.HMRC);
+        amlSupervisoryBodies1.setMembershipId("12345678");
+        AMLSupervisoryBodiesDto[] amlSupervisoryBodies = new AMLSupervisoryBodiesDto[]{amlSupervisoryBodies1};
+        acspDataDto.setAmlSupervisoryBodies(amlSupervisoryBodies);
+
+        AMLSupervisoryBodiesDto amlSupervisoryBodies2 = new AMLSupervisoryBodiesDto();
+        amlSupervisoryBodies2.setAmlSupervisoryBody(AMLSupervisoryBodies.FCA);
+        amlSupervisoryBodies2.setMembershipId("87654321");
+        AMLSupervisoryBodiesDto[] removedAmlSupervisoryBodies = new AMLSupervisoryBodiesDto[]{amlSupervisoryBodies2};
+        acspDataDto.setRemovedAmlSupervisoryBodies(removedAmlSupervisoryBodies);
+
+        when(acspService.getAcsp(any(), any())).thenReturn(Optional.of(acspDataDto));
+        when(transactionService.getTransaction(PASS_THROUGH_HEADER, TRANSACTION_ID)).thenReturn(transaction);
+
+        var response = filingsService.generateAcspApplicationFiling(ACSP_ID, TRANSACTION_ID, PASS_THROUGH_HEADER);
+
+        Assertions.assertNotNull(response.getData());
+        Assertions.assertEquals(ACSP_ID.toUpperCase(), response.getData().get("incorporation_number"));
+        Assertions.assertEquals(EMAIL_ADDRESS.toUpperCase(), response.getData().get("email"));
+        Assertions.assertEquals("Test LLP Company Name Update ACSP".toUpperCase(), response.getData().get("proposed_corporate_body_name"));
+        Assertions.assertNotNull(response.getData().get("acsp_details"));
+        Assertions.assertNotNull(response.getData().get("registered_office_address"));
+        Assertions.assertNotNull(response.getData().get("service_address"));
+        Assertions.assertNull(response.getData().get("st_personal_information"));
+
+        Aml acspDetails = (Aml) response.getData().get("acsp_details");
+        Assertions.assertNotNull(acspDetails.getAmlMemberships());
+        Assertions.assertEquals(1, acspDetails.getAmlMemberships().length);
+        Arrays.stream(acspDetails.getAmlMemberships()).forEach(
+                amlMembership -> {
+                    Assertions.assertEquals("12345678", amlMembership.getRegistrationNumber());
+                    Assertions.assertEquals(AMLSupervisoryBodies.HMRC.name(), amlMembership.getSupervisoryBody().toUpperCase());
+                }
+        );
+
+        Assertions.assertNotNull(acspDetails.getPreviousAmlMemberships());
+        Assertions.assertEquals(1, acspDetails.getPreviousAmlMemberships().length);
+        Arrays.stream(acspDetails.getPreviousAmlMemberships()).forEach(
+                amlMembership -> {
+                    Assertions.assertEquals("87654321", amlMembership.getRegistrationNumber());
+                    Assertions.assertEquals(AMLSupervisoryBodies.FCA.name(), amlMembership.getSupervisoryBody().toUpperCase());
+                }
+        );
+    }
+
+    @Test
+    void testGenerateAllDataUpdateCorporateBodyAcsp() throws Exception {
+        setACSPDataDto();
+        acspDataDto.setAcspType(AcspType.UPDATE_ACSP);
+        acspDataDto.setAcspId(ACSP_ID);
+        acspDataDto.getApplicantDetails().setCorrespondenceEmail(EMAIL_ADDRESS);
+        acspDataDto.setBusinessName("Test Corporate Body Name Update ACSP");
+        acspDataDto.setRegisteredOfficeAddress(buildBusinessAddress());
+        acspDataDto.getApplicantDetails().setCorrespondenceAddress(buildCorrespondenceAddress());
+        acspDataDto.setTypeOfBusiness(TypeOfBusiness.CORPORATE_BODY);
+
+        AMLSupervisoryBodiesDto amlSupervisoryBodies1 = new AMLSupervisoryBodiesDto();
+        amlSupervisoryBodies1.setAmlSupervisoryBody(AMLSupervisoryBodies.HMRC);
+        amlSupervisoryBodies1.setMembershipId("12345678");
+        AMLSupervisoryBodiesDto[] amlSupervisoryBodies = new AMLSupervisoryBodiesDto[]{amlSupervisoryBodies1};
+        acspDataDto.setAmlSupervisoryBodies(amlSupervisoryBodies);
+
+        AMLSupervisoryBodiesDto amlSupervisoryBodies2 = new AMLSupervisoryBodiesDto();
+        amlSupervisoryBodies2.setAmlSupervisoryBody(AMLSupervisoryBodies.FCA);
+        amlSupervisoryBodies2.setMembershipId("87654321");
+        AMLSupervisoryBodiesDto[] removedAmlSupervisoryBodies = new AMLSupervisoryBodiesDto[]{amlSupervisoryBodies2};
+        acspDataDto.setRemovedAmlSupervisoryBodies(removedAmlSupervisoryBodies);
+
+        when(acspService.getAcsp(any(), any())).thenReturn(Optional.of(acspDataDto));
+        when(transactionService.getTransaction(PASS_THROUGH_HEADER, TRANSACTION_ID)).thenReturn(transaction);
+
+        var response = filingsService.generateAcspApplicationFiling(ACSP_ID, TRANSACTION_ID, PASS_THROUGH_HEADER);
+
+        Assertions.assertNotNull(response.getData());
+        Assertions.assertEquals(ACSP_ID.toUpperCase(), response.getData().get("incorporation_number"));
+        Assertions.assertEquals(EMAIL_ADDRESS.toUpperCase(), response.getData().get("email"));
+        Assertions.assertEquals("Test Corporate Body Name Update ACSP".toUpperCase(), response.getData().get("proposed_corporate_body_name"));
+        Assertions.assertNotNull(response.getData().get("acsp_details"));
+        Assertions.assertNotNull(response.getData().get("registered_office_address"));
+        Assertions.assertNotNull(response.getData().get("service_address"));
+        Assertions.assertNull(response.getData().get("st_personal_information"));
+
+        Aml acspDetails = (Aml) response.getData().get("acsp_details");
+        Assertions.assertNotNull(acspDetails.getAmlMemberships());
+        Assertions.assertEquals(1, acspDetails.getAmlMemberships().length);
+        Arrays.stream(acspDetails.getAmlMemberships()).forEach(
+                amlMembership -> {
+                    Assertions.assertEquals("12345678", amlMembership.getRegistrationNumber());
+                    Assertions.assertEquals(AMLSupervisoryBodies.HMRC.name(), amlMembership.getSupervisoryBody().toUpperCase());
+                }
+        );
+
+        Assertions.assertNotNull(acspDetails.getPreviousAmlMemberships());
+        Assertions.assertEquals(1, acspDetails.getPreviousAmlMemberships().length);
+        Arrays.stream(acspDetails.getPreviousAmlMemberships()).forEach(
+                amlMembership -> {
+                    Assertions.assertEquals("87654321", amlMembership.getRegistrationNumber());
+                    Assertions.assertEquals(AMLSupervisoryBodies.FCA.name(), amlMembership.getSupervisoryBody().toUpperCase());
+                }
+        );
+    }
+
+    @Test
     void testGenerateAllDataUpdateSoleTraderAcsp() throws Exception {
         setACSPDataDto();
         acspDataDto.setAcspType(AcspType.UPDATE_ACSP);

--- a/src/test/java/uk/gov/companieshouse/acsp/service/FilingServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/acsp/service/FilingServiceTest.java
@@ -950,14 +950,14 @@ class FilingServiceTest {
     }
 
     @Test
-    void testGenerateAllDataUpdateCorporateBodyAcsp() throws Exception {
+    void testGenerateAllDataUpdateCorporateBodyAcspWithNullCorrespondenceAddress() throws Exception {
         setACSPDataDto();
         acspDataDto.setAcspType(AcspType.UPDATE_ACSP);
         acspDataDto.setAcspId(ACSP_ID);
         acspDataDto.getApplicantDetails().setCorrespondenceEmail(EMAIL_ADDRESS);
         acspDataDto.setBusinessName("Test Corporate Body Name Update ACSP");
         acspDataDto.setRegisteredOfficeAddress(buildBusinessAddress());
-        acspDataDto.getApplicantDetails().setCorrespondenceAddress(buildCorrespondenceAddress());
+        acspDataDto.getApplicantDetails().setCorrespondenceAddress(null); // Set CorrespondenceAddress to null
         acspDataDto.setTypeOfBusiness(TypeOfBusiness.CORPORATE_BODY);
 
         AMLSupervisoryBodiesDto amlSupervisoryBodies1 = new AMLSupervisoryBodiesDto();
@@ -983,7 +983,7 @@ class FilingServiceTest {
         Assertions.assertEquals("Test Corporate Body Name Update ACSP".toUpperCase(), response.getData().get("proposed_corporate_body_name"));
         Assertions.assertNotNull(response.getData().get("acsp_details"));
         Assertions.assertNotNull(response.getData().get("registered_office_address"));
-        Assertions.assertNotNull(response.getData().get("service_address"));
+        Assertions.assertNull(response.getData().get("service_address")); // Ensure service_address is null
         Assertions.assertNull(response.getData().get("st_personal_information"));
 
         Aml acspDetails = (Aml) response.getData().get("acsp_details");


### PR DESCRIPTION
__Short description outlining key changes/additions__

- Adding new method buildUpdateAcspData to FilingService to build the update ACSP data structure that CHIPS expects when sending an Update ACSP application.
- Updating AcspDataDao and Dto models to include fields for removed AML supervisory bodies and the ACSP id of the application (e.g "AP123456")
- Updating AML model to include field for previous aml memberships (used when a user has selected to remove AML bodies as part of their update ACSP submission.
- Adding isRegistration boolean within the setFilingApiData method. This is used to differentiate between Registration and Update ACSP applications (as there is a cost associated with ACSP registration and not with Updating ACSP details).
- Adding 'isRemoved' boolean to buildAmlMemberships() method signature. The boolean value is used in a ternary check to determine wether there is data to be set for removed aml bodies in an Update ACSP Details application.
- Added new unit tests
- Updating existing tests to include AcspType check (setting to REGISTER_ACSP when tests include checking payment details)

__JIRA Ticket Number__

[IDVA5-1773](https://companieshouse.atlassian.net/browse/IDVA5-1773)

### Type of change

* [ ] Bug fix
* [x] New feature
* [ ] Breaking change
* [ ] Infrastructure change

### Pull request checklist

* [x] I have added unit tests for new code that I have added
* [x] I have added/updated functional tests where appropriate
* [x] The code follows our [coding standards](https://github.com/companieshouse/styleguides/blob/master/java.md)

__An exhaustive list of peer review checks can be read [here](https://github.com/companieshouse/styleguides/blob/master/java_review.md#developer-actions-prior-to-code-commitreview-started)__

[IDVA5-1773]: https://companieshouse.atlassian.net/browse/IDVA5-1773?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ