### PR TITLE
Fix for CVE-2025-22235, CVE-2025-31651, CVE-2025-31650

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,10 +13,10 @@
 	<description>ACSP workstream</description>
 	<properties>
 		<java.version>21</java.version>
-		<spring.boot.version>3.4.4</spring.boot.version>
+		<spring.boot.version>3.4.5</spring.boot.version>
 		<main.class>uk.gov.companieshouse.acsp.AcspApplication</main.class>
-		<spring-boot-dependencies.version>3.4.4</spring-boot-dependencies.version>
-		<spring-boot-maven-plugin.version>3.4.4</spring-boot-maven-plugin.version>
+		<spring-boot-dependencies.version>3.4.5</spring-boot-dependencies.version>
+		<spring-boot-maven-plugin.version>3.4.5</spring-boot-maven-plugin.version>
 		<maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
 		<org.mapstruct.version>1.6.3</org.mapstruct.version>
 		<private-api-sdk-java.version>4.0.4</private-api-sdk-java.version>


### PR DESCRIPTION
__Short description outlining key changes/additions__
Upgrading Spring Boot to 3.4.5 (Tomcat upgraded to 10.1.40) to address following vulnerabilities:

- CVE-2025-22235
- CVE-2025-31651
- CVE-2025-31650