### PR TITLE
Updating FilingsService to include usual residence field

### DIFF
--- a/src/main/java/uk/gov/companieshouse/acsp/service/FilingsService.java
+++ b/src/main/java/uk/gov/companieshouse/acsp/service/FilingsService.java
@@ -141,7 +141,7 @@ public class FilingsService {
               .map(String::toUpperCase).orElse(null));
     }
 
-    if (TypeOfBusiness.SOLE_TRADER.equals(acspDataDto.getTypeOfBusiness())) {
+    if (TypeOfBusiness.SOLE_TRADER.equals(acspDataDto.getTypeOfBusiness()) || AcspType.UPDATE_ACSP.equals(acspDataDto.getAcspType())) {
       data.put(ST_PERSONAL_INFORMATION, buildStPersonalInformation(acspDataDto));
     }
 

--- a/src/test/java/uk/gov/companieshouse/acsp/service/FilingServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/acsp/service/FilingServiceTest.java
@@ -856,7 +856,7 @@ class FilingServiceTest {
         Assertions.assertNotNull(response.getData().get(AML));
         Assertions.assertNotNull(response.getData().get(REGISTERED_OFFICE_ADDRESS));
         Assertions.assertNotNull(response.getData().get(SERVICE_ADDRESS));
-        Assertions.assertNull(response.getData().get(ST_PERSONAL_INFORMATION));
+        Assertions.assertNotNull(response.getData().get(ST_PERSONAL_INFORMATION));
 
         Aml acspDetails = (Aml) response.getData().get(AML);
         Assertions.assertNotNull(acspDetails.getAmlMemberships());
@@ -912,7 +912,7 @@ class FilingServiceTest {
         Assertions.assertNotNull(response.getData().get(AML));
         Assertions.assertNotNull(response.getData().get(REGISTERED_OFFICE_ADDRESS));
         Assertions.assertNotNull(response.getData().get(SERVICE_ADDRESS));
-        Assertions.assertNull(response.getData().get(ST_PERSONAL_INFORMATION));
+        Assertions.assertNotNull(response.getData().get(ST_PERSONAL_INFORMATION));
 
         Aml acspDetails = (Aml) response.getData().get(AML);
         Assertions.assertNotNull(acspDetails.getAmlMemberships());
@@ -972,7 +972,6 @@ class FilingServiceTest {
         Assertions.assertNotNull(response.getData().get(REGISTERED_OFFICE_ADDRESS));
         Assertions.assertNotNull(response.getData().get(SERVICE_ADDRESS));
         Assertions.assertNotNull(response.getData().get(ST_PERSONAL_INFORMATION));
-        Assertions.assertNotNull(response.getData().get(ST_PERSONAL_INFORMATION));
 
         var stPersonalInformation = (STPersonalInformation) response.getData().get(ST_PERSONAL_INFORMATION);
         Assertions.assertEquals(FIRST_NAME.toUpperCase(), stPersonalInformation.getPersonName().getFirstName());
@@ -1006,6 +1005,33 @@ class FilingServiceTest {
     }
 
     @Test
+    void testBuildStPersonalInformationWithNullsAndCountryOfResidence() throws Exception {
+        setACSPDataDto();
+        acspDataDto.setAcspType(AcspType.UPDATE_ACSP);
+        acspDataDto.setAcspId("AP654321");
+        // Set applicant details with only country of residence
+        acspDataDto.getApplicantDetails().setFirstName(null);
+        acspDataDto.getApplicantDetails().setLastName(null);
+        acspDataDto.getApplicantDetails().setMiddleName(null);
+        acspDataDto.getApplicantDetails().setDateOfBirth(null);
+        acspDataDto.getApplicantDetails().setCountryOfResidence("FRANCE");
+        acspDataDto.getApplicantDetails().setNationality(null);
+
+        when(acspService.getAcsp(any(), any())).thenReturn(Optional.of(acspDataDto));
+        when(transactionService.getTransaction(PASS_THROUGH_HEADER, TRANSACTION_ID)).thenReturn(transaction);
+
+        var response = filingsService.generateAcspApplicationFiling("AP654321", TRANSACTION_ID, PASS_THROUGH_HEADER);
+
+        Object stPersonalInfoObj = response.getData().get(ST_PERSONAL_INFORMATION);
+        Assertions.assertNotNull(stPersonalInfoObj);
+        STPersonalInformation stPersonalInfo = (STPersonalInformation) stPersonalInfoObj;
+        Assertions.assertNull(stPersonalInfo.getPersonName());
+        Assertions.assertNull(stPersonalInfo.getBirthDate());
+        Assertions.assertEquals("FRANCE", stPersonalInfo.getUsualResidence());
+        Assertions.assertNull(stPersonalInfo.getNationalityOther());
+    }
+
+    @Test
     void testGenerateUpdateCorporateBodyAcspWithNullCorrespondenceAddress() throws Exception {
         setACSPDataDto();
         acspDataDto.setAcspType(AcspType.UPDATE_ACSP);
@@ -1026,8 +1052,8 @@ class FilingServiceTest {
         Assertions.assertEquals("Test Corporate Body Name Update ACSP".toUpperCase(), response.getData().get(BUSINESS_NAME));
         Assertions.assertNotNull(response.getData().get(AML));
         Assertions.assertNotNull(response.getData().get(REGISTERED_OFFICE_ADDRESS));
+        Assertions.assertNotNull(response.getData().get(ST_PERSONAL_INFORMATION));
         Assertions.assertNull(response.getData().get(SERVICE_ADDRESS));
-        Assertions.assertNull(response.getData().get(ST_PERSONAL_INFORMATION));
     }
 
     @Test
@@ -1065,6 +1091,12 @@ class FilingServiceTest {
         acspDataDto.setRegisteredOfficeAddress(null);
         acspDataDto.getApplicantDetails().setCorrespondenceAddress(null);
         acspDataDto.setTypeOfBusiness(null);
+        acspDataDto.getApplicantDetails().setFirstName(null);
+        acspDataDto.getApplicantDetails().setMiddleName(null);
+        acspDataDto.getApplicantDetails().setLastName(null);
+        acspDataDto.getApplicantDetails().setDateOfBirth(null);
+        acspDataDto.getApplicantDetails().setCountryOfResidence(null);
+        acspDataDto.getApplicantDetails().setNationality(null);
 
         when(acspService.getAcsp(any(), any())).thenReturn(Optional.of(acspDataDto));
         when(transactionService.getTransaction(PASS_THROUGH_HEADER, TRANSACTION_ID)).thenReturn(transaction);
@@ -1077,6 +1109,13 @@ class FilingServiceTest {
         Assertions.assertNotNull(response.getData().get(AML));
         Assertions.assertNull(response.getData().get(REGISTERED_OFFICE_ADDRESS));
         Assertions.assertNull(response.getData().get(SERVICE_ADDRESS));
-        Assertions.assertNull(response.getData().get(ST_PERSONAL_INFORMATION));
+
+        Object stPersonalInfoObj = response.getData().get(ST_PERSONAL_INFORMATION);
+        Assertions.assertNotNull(stPersonalInfoObj);
+        STPersonalInformation stPersonalInfo = (STPersonalInformation) stPersonalInfoObj;
+        Assertions.assertNull(stPersonalInfo.getPersonName());
+        Assertions.assertNull(stPersonalInfo.getBirthDate());
+        Assertions.assertNull(stPersonalInfo.getUsualResidence());
+        Assertions.assertNull(stPersonalInfo.getNationalityOther());
     }
 }


### PR DESCRIPTION
__Short description outlining key changes/additions__

- It is required that we send the country of residence value to chips-filing-consumer for Sole Traders as it expects this data from Update Acsp application. The FilingsService has been updated to send this through the Filings Endpoint.
- The existing function buildStPersonalInformation includes the field needed for country of residence, however this method was not previously called when using the update acsp service (as the previous check was only checking for Type of business and we only send this through Acsp Registration applications).
- Updated the if statement to now call the buildStPersonalInformation when the AcspType is set to Update Acsp, which allows the country of residence value to be updated and sent to chips-filing-consumer.
- As a side note, chips-filing-consumer checks for null values and removes them when processing applications, which means the date of birth and nationalities fields are unaffected through the buildStPersonalInformation function (as these cannot be updated through an Update Acsp application and will always result to null)
- Unit tests updated to reflect inclusion of buildStPersonalInformation function

__JIRA Ticket Number__
[IDVA5-2186](https://companieshouse.atlassian.net/browse/IDVA5-2186)

### Type of change

* [ ] Bug fix
* [x] New feature
* [ ] Breaking change
* [ ] Infrastructure change

### Pull request checklist

* [x] I have added unit tests for new code that I have added
* [x] I have added/updated functional tests where appropriate
* [x] The code follows our [coding standards](https://github.com/companieshouse/styleguides/blob/master/java.md)

__An exhaustive list of peer review checks can be read [here](https://github.com/companieshouse/styleguides/blob/master/java_review.md#developer-actions-prior-to-code-commitreview-started)__

[IDVA5-2186]: https://companieshouse.atlassian.net/browse/IDVA5-2186?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ