### PR TITLE
Filing endpoint changes for Close ACSP

### DIFF
--- a/src/main/java/uk/gov/companieshouse/acsp/util/TransactionUtils.java
+++ b/src/main/java/uk/gov/companieshouse/acsp/util/TransactionUtils.java
@@ -10,6 +10,7 @@ import java.util.Map;
 import java.util.Objects;
 
 import static uk.gov.companieshouse.acsp.util.Constants.FILING_KIND_ACSP;
+import static uk.gov.companieshouse.acsp.util.Constants.FILING_KIND_CLOSE_ACSP;
 import static uk.gov.companieshouse.acsp.util.Constants.FILING_KIND_UPDATE_ACSP;
 import static uk.gov.companieshouse.acsp.util.Constants.LINK_RESOURCE;
 
@@ -33,7 +34,7 @@ public class TransactionUtils {
         }
 
         return transaction.getResources().entrySet().stream()
-                .filter(resource -> FILING_KIND_ACSP.equals(resource.getValue().getKind()) || FILING_KIND_UPDATE_ACSP.equals((resource.getValue().getKind())))
+                .filter(resource -> FILING_KIND_ACSP.equals(resource.getValue().getKind()) || FILING_KIND_UPDATE_ACSP.equals((resource.getValue().getKind())) || FILING_KIND_CLOSE_ACSP.equals((resource.getValue().getKind())))
                 .anyMatch(resource -> acspSubmissionSelfLink.equals(resource.getValue().getLinks().get(LINK_RESOURCE)));
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -14,6 +14,7 @@ ACSP01_COST=${ACSP01_COST}
 ACSP_APPLICATION_FILING_DESCRIPTION_IDENTIFIER=${ACSP_APPLICATION_FILING_DESCRIPTION_IDENTIFIER:**ACSP Application** submission made}
 ACSP_APPLICATION_FILING_DESCRIPTION=${ACSP_APPLICATION_FILING_DESCRIPTION:acsp application made}
 ACSP_UPDATE_FILING_DESCRIPTION=${ACSP_UPDATE_FILING_DESCRIPTION:update acsp application made}
+ACSP_CLOSE_FILING_DESCRIPTION=${ACSP_CLOSE_FILING_DESCRIPTION:close acsp application made}
 # Spring MongoDB
 spring.data.mongodb.field-naming-strategy=org.springframework.data.mapping.model.SnakeCaseFieldNamingStrategy
 

--- a/src/test/java/uk/gov/companieshouse/acsp/service/FilingServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/acsp/service/FilingServiceTest.java
@@ -1118,4 +1118,22 @@ class FilingServiceTest {
         Assertions.assertNull(stPersonalInfo.getUsualResidence());
         Assertions.assertNull(stPersonalInfo.getNationalityOther());
     }
+
+    @Test
+    void testBuildCloseAcspDataWithNonNullData() throws Exception {
+        acspDataDto = new AcspDataDto();
+        acspDataDto.setAcspType(AcspType.CLOSE_ACSP);
+        acspDataDto.setAcspId(ACSP_ID);
+        AcspDataSubmissionDto dataSubmissionDto = new AcspDataSubmissionDto();
+        dataSubmissionDto.setUpdatedAt(LocalDateTime.now());
+        acspDataDto.setAcspDataSubmission(dataSubmissionDto);
+
+        when(acspService.getAcsp(any(), any())).thenReturn(Optional.of(acspDataDto));
+        when(transactionService.getTransaction(PASS_THROUGH_HEADER, TRANSACTION_ID)).thenReturn(transaction);
+
+        var response = filingsService.generateAcspApplicationFiling(ACSP_ID, TRANSACTION_ID, PASS_THROUGH_HEADER);
+
+        Assertions.assertNotNull(response.getData());
+        Assertions.assertEquals(ACSP_ID.toUpperCase(), response.getData().get("company_number"));
+    }
 }


### PR DESCRIPTION
__Short description outlining key changes/additions__
- Updated filing endpoint by adding in checks for acspType to set appropriate fields within FilingService.
- Update and Close ACSP both set company_number so have added this within an if block
- FILING_KIND_CLOSE_ACSP added as "acsp#cessation"
- ACSP_CLOSE_FILING_DESCRIPTION added as "close acsp application made"
- New unit test added for Close ACSP scenario
- Tested in Postman with following response:

```
[
    {
        "data": {
            "company_number": "AP123456"
        },
        "description": "CLOSE ACSP APPLICATION MADE",
        "description_identifier": "**ACSP APPLICATION** SUBMISSION MADE",
        "description_values": {},
        "kind": "acsp#cessation"
    }
]
```

__JIRA Ticket Number__
https://companieshouse.atlassian.net/browse/IDVA5-1793

### Type of change

* [ ] Bug fix
* [X] New feature
* [ ] Breaking change
* [ ] Infrastructure change

### Pull request checklist

* [X] I have added unit tests for new code that I have added
* [ ] I have added/updated functional tests where appropriate
* [X] The code follows our [coding standards](https://github.com/companieshouse/styleguides/blob/master/java.md)

__An exhaustive list of peer review checks can be read [here](https://github.com/companieshouse/styleguides/blob/master/java_review.md#developer-actions-prior-to-code-commitreview-started)__