### PR TITLE
Updating email service to trigger email sending for reverification

### DIFF
--- a/src/main/java/uk/gov/companieshouse/acsp/controllers/VerifyClientController.java
+++ b/src/main/java/uk/gov/companieshouse/acsp/controllers/VerifyClientController.java
@@ -31,19 +31,13 @@ public class VerifyClientController {
         try{
             ApplicationType applicationType = ApplicationType.findByLabel(applicationTypeParam);
 
-            if (ApplicationType.VERIFICATION.equals(applicationType)) {
-                emailService.sendClientVerificationEmail(
-                        clientVerificationEmailDao.getTo(),
-                        clientVerificationEmailDao.getClientName(),
-                        clientVerificationEmailDao.getReferenceNumber(),
-                        clientVerificationEmailDao.getClientEmailAddress());
-            } else {
-                emailService.sendClientReverificationEmail(
-                        clientVerificationEmailDao.getTo(),
-                        clientVerificationEmailDao.getClientName(),
-                        clientVerificationEmailDao.getReferenceNumber(),
-                        clientVerificationEmailDao.getClientEmailAddress());
-            }
+            emailService.sendClientVerificationEmail(
+                    clientVerificationEmailDao.getTo(),
+                    clientVerificationEmailDao.getClientName(),
+                    clientVerificationEmailDao.getReferenceNumber(),
+                    clientVerificationEmailDao.getClientEmailAddress(),
+                    applicationType);
+
             return ResponseEntity.ok().build();
         } catch (Exception e) {
             LOGGER.error("Error sending email for identity-verification " + e.getMessage());

--- a/src/main/java/uk/gov/companieshouse/acsp/mapper/EnumTranslator.java
+++ b/src/main/java/uk/gov/companieshouse/acsp/mapper/EnumTranslator.java
@@ -80,4 +80,10 @@ public class EnumTranslator {
         return AcspType.findByLabel(inputStr);
     }
 
+    @Named("ApplicationTypeEnumToString")
+    public String applicationTypeEnumToString(ApplicationType inputEnum) { return inputEnum != null ? inputEnum.getLabel() : ""; }
+
+    @Named("ApplicationTypeStringToEnum")
+    public ApplicationType applicationTypeStringToEnum(String inputStr) { return ApplicationType.findByLabel(inputStr); }
+
 }

--- a/src/main/java/uk/gov/companieshouse/acsp/models/enums/ApplicationType.java
+++ b/src/main/java/uk/gov/companieshouse/acsp/models/enums/ApplicationType.java
@@ -1,0 +1,25 @@
+package uk.gov.companieshouse.acsp.models.enums;
+
+public enum ApplicationType {
+    VERIFICATION("verification"),
+    REVERIFICATION("reverification");
+
+    public final String label;
+
+    ApplicationType(String label) {
+        this.label = label;
+    }
+
+    public String getLabel() {
+        return label;
+    }
+
+    public static ApplicationType findByLabel(String label) {
+        for (ApplicationType v : values()) {
+            if (v.label.equals(label)) {
+                return v;
+            }
+        }
+        return VERIFICATION;
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/acsp/service/EmailService.java
+++ b/src/main/java/uk/gov/companieshouse/acsp/service/EmailService.java
@@ -16,7 +16,8 @@ import static uk.gov.companieshouse.acsp.AcspApplication.APP_NAMESPACE;
 public class EmailService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(APP_NAMESPACE);
-    private static final String EMAIL_SUBJECT = "Identity verified for client: ";
+    private static final String VERIFY_EMAIL_SUBJECT = "Identity verified for client: ";
+    private static final String REVERIFY_EMAIL_SUBJECT = "Identity reverified for client: ";
     private final EmailProducer emailProducer;
 
     public EmailService(EmailProducer emailProducer) {
@@ -31,8 +32,20 @@ public class EmailService {
         emailData.setReferenceNumber(referenceNumber);
         emailData.setClientEmailAddress(clientEmailAddress);
         emailData.setTo(recipientEmailAddress);
-        emailData.setSubject(EMAIL_SUBJECT + clientName);
+        emailData.setSubject(VERIFY_EMAIL_SUBJECT + clientName);
         sendEmail(emailData, "acsp_client_verification_email");
+    }
+
+    public void sendClientReverificationEmail(final String recipientEmailAddress, final String clientName, final String referenceNumber, final String clientEmailAddress) {
+        LOGGER.info("Sending client reverification email for application: " + referenceNumber);
+
+        final var emailData = new ClientVerificationEmailData();
+        emailData.setClientName(clientName);
+        emailData.setReferenceNumber(referenceNumber);
+        emailData.setClientEmailAddress(clientEmailAddress);
+        emailData.setTo(recipientEmailAddress);
+        emailData.setSubject(REVERIFY_EMAIL_SUBJECT + clientName);
+        sendEmail(emailData, "acsp_client_reverification_email");
     }
 
     private void sendEmail(final EmailData emailData, final String messageType) throws EmailSendingException {

--- a/src/main/java/uk/gov/companieshouse/acsp/service/EmailService.java
+++ b/src/main/java/uk/gov/companieshouse/acsp/service/EmailService.java
@@ -3,6 +3,7 @@ package uk.gov.companieshouse.acsp.service;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.stereotype.Service;
 import uk.gov.companieshouse.acsp.models.email.ClientVerificationEmailData;
+import uk.gov.companieshouse.acsp.models.enums.ApplicationType;
 import uk.gov.companieshouse.email_producer.EmailProducer;
 import uk.gov.companieshouse.email_producer.EmailSendingException;
 import uk.gov.companieshouse.email_producer.model.EmailData;
@@ -24,28 +25,22 @@ public class EmailService {
         this.emailProducer = emailProducer;
     }
 
-    public void sendClientVerificationEmail(final String recipientEmailAddress, final String clientName, final String referenceNumber, final String clientEmailAddress) {
-        LOGGER.info("Sending client verification email for application: " + referenceNumber);
+    public void sendClientVerificationEmail(final String recipientEmailAddress, final String clientName, final String referenceNumber, final String clientEmailAddress, final ApplicationType applicationType) {
+        LOGGER.info("Sending client " + applicationType.getLabel() + " email for application: " + referenceNumber);
 
         final var emailData = new ClientVerificationEmailData();
         emailData.setClientName(clientName);
         emailData.setReferenceNumber(referenceNumber);
         emailData.setClientEmailAddress(clientEmailAddress);
         emailData.setTo(recipientEmailAddress);
-        emailData.setSubject(VERIFY_EMAIL_SUBJECT + clientName);
-        sendEmail(emailData, "acsp_client_verification_email");
-    }
 
-    public void sendClientReverificationEmail(final String recipientEmailAddress, final String clientName, final String referenceNumber, final String clientEmailAddress) {
-        LOGGER.info("Sending client reverification email for application: " + referenceNumber);
-
-        final var emailData = new ClientVerificationEmailData();
-        emailData.setClientName(clientName);
-        emailData.setReferenceNumber(referenceNumber);
-        emailData.setClientEmailAddress(clientEmailAddress);
-        emailData.setTo(recipientEmailAddress);
-        emailData.setSubject(REVERIFY_EMAIL_SUBJECT + clientName);
-        sendEmail(emailData, "acsp_client_reverification_email");
+        if (ApplicationType.REVERIFICATION.equals(applicationType)) {
+            emailData.setSubject(REVERIFY_EMAIL_SUBJECT + clientName);
+            sendEmail(emailData, "acsp_client_reverification_email");
+        } else {
+            emailData.setSubject(VERIFY_EMAIL_SUBJECT + clientName);
+            sendEmail(emailData, "acsp_client_verification_email");
+        }
     }
 
     private void sendEmail(final EmailData emailData, final String messageType) throws EmailSendingException {

--- a/src/test/java/uk/gov/companieshouse/acsp/controllers/VerifyClientControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/acsp/controllers/VerifyClientControllerTest.java
@@ -10,6 +10,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import uk.gov.companieshouse.acsp.models.email.ClientVerificationEmailData;
+import uk.gov.companieshouse.acsp.models.enums.ApplicationType;
 import uk.gov.companieshouse.acsp.service.EmailService;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -45,7 +46,8 @@ public class VerifyClientControllerTest {
                 emailData.getTo(),
                 emailData.getClientName(),
                 emailData.getReferenceNumber(),
-                emailData.getClientEmailAddress());
+                emailData.getClientEmailAddress(),
+                ApplicationType.VERIFICATION);
         assertEquals(HttpStatus.OK, response.getStatusCode());
     }
 
@@ -57,7 +59,8 @@ public class VerifyClientControllerTest {
                 emailData.getTo(),
                 emailData.getClientName(),
                 emailData.getReferenceNumber(),
-                emailData.getClientEmailAddress());
+                emailData.getClientEmailAddress(),
+                ApplicationType.VERIFICATION);
         assertEquals(HttpStatus.OK, response.getStatusCode());
     }
 
@@ -65,11 +68,12 @@ public class VerifyClientControllerTest {
     void sendIdentityReverificationEmailSuccess() {
         ResponseEntity<?> response = verifyClientController.sendIdentityVerificationEmail(emailData, "reverification");
 
-        verify(emailService).sendClientReverificationEmail(
+        verify(emailService).sendClientVerificationEmail(
                 emailData.getTo(),
                 emailData.getClientName(),
                 emailData.getReferenceNumber(),
-                emailData.getClientEmailAddress());
+                emailData.getClientEmailAddress(),
+                ApplicationType.REVERIFICATION);
         assertEquals(HttpStatus.OK, response.getStatusCode());
     }
 
@@ -80,7 +84,8 @@ public class VerifyClientControllerTest {
                         emailData.getTo(),
                         emailData.getClientName(),
                         emailData.getReferenceNumber(),
-                        emailData.getClientEmailAddress());
+                        emailData.getClientEmailAddress(),
+                        ApplicationType.VERIFICATION);
 
         ResponseEntity<?> response = verifyClientController.sendIdentityVerificationEmail(emailData, "verification");
 
@@ -90,11 +95,12 @@ public class VerifyClientControllerTest {
     @Test
     void sendIdentityReverificationEmailFailure() {
         doThrow(RuntimeException.class).when(emailService)
-                .sendClientReverificationEmail(
+                .sendClientVerificationEmail(
                         emailData.getTo(),
                         emailData.getClientName(),
                         emailData.getReferenceNumber(),
-                        emailData.getClientEmailAddress());
+                        emailData.getClientEmailAddress(),
+                        ApplicationType.REVERIFICATION);
 
         ResponseEntity<?> response = verifyClientController.sendIdentityVerificationEmail(emailData, "reverification");
 

--- a/src/test/java/uk/gov/companieshouse/acsp/mapper/EnumTranslatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/acsp/mapper/EnumTranslatorTest.java
@@ -170,7 +170,38 @@ import uk.gov.companieshouse.acsp.models.enums.*;
 
         assertEquals(expected, actual);
     }
+
+    @Test
+    void applicationTypeEnumToString() {
+        ApplicationType inputEnum = ApplicationType.VERIFICATION;
+        String expected = "verification";
+        String actual = enumTranslator.applicationTypeEnumToString(inputEnum);
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void applicationTypeEnumToStringNull() {
+        String expected = "";
+        String actual = enumTranslator.applicationTypeEnumToString(null);
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void applicationTypeStringToEnum() {
+        String inputEnum = ApplicationType.REVERIFICATION.label;
+        ApplicationType expected = ApplicationType.REVERIFICATION;
+        ApplicationType actual = enumTranslator.applicationTypeStringToEnum(inputEnum);
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void applicationTypeStringToEnumInvalid() {
+        String inputString = "invalid_application_type";
+        ApplicationType expected = ApplicationType.VERIFICATION;
+        ApplicationType actual = enumTranslator.applicationTypeStringToEnum(inputString);
+        assertEquals(expected, actual);
+    }
 }
-
-
-

--- a/src/test/java/uk/gov/companieshouse/acsp/service/EmailServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/acsp/service/EmailServiceTest.java
@@ -13,6 +13,7 @@ import uk.gov.companieshouse.email_producer.model.EmailData;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
@@ -35,27 +36,51 @@ public class EmailServiceTest {
         emailData.setReferenceNumber("12345");
         emailData.setClientEmailAddress("client@example.com");
         emailData.setTo("recipient@example.com");
-        emailData.setSubject("Identity verified for client: Client Name");
     }
 
     @Test
     void sendClientVerificationEmailSuccess() throws EmailSendingException {
         emailService.sendClientVerificationEmail(
-                "recipient@example.com",
-                "Client Name",
-                "12345",
-                "client@example.com");
+                emailData.getTo(),
+                emailData.getClientName(),
+                emailData.getReferenceNumber(),
+                emailData.getClientEmailAddress());
 
-        verify(emailProducer).sendEmail(any(EmailData.class), eq("acsp_client_verification_email"));
+        verify(emailProducer).sendEmail(
+                argThat(emailData -> "Identity verified for client: Client Name".equals(emailData.getSubject())),
+                eq("acsp_client_verification_email"));
     }
 
     @Test
     void sendClientVerificationEmailFailure() throws EmailSendingException {
         doThrow(EmailSendingException.class).when(emailProducer).sendEmail(any(EmailData.class), eq("acsp_client_verification_email"));
         assertThrows(EmailSendingException.class, () -> emailService.sendClientVerificationEmail(
-                "recipient@example.com",
-                "Client Name",
-                "12345",
-                "client@example.com"));
+                emailData.getTo(),
+                emailData.getClientName(),
+                emailData.getReferenceNumber(),
+                emailData.getClientEmailAddress()));
+    }
+
+    @Test
+    void sendClientReverificationEmailSuccess() throws EmailSendingException {
+        emailService.sendClientReverificationEmail(
+                emailData.getTo(),
+                emailData.getClientName(),
+                emailData.getReferenceNumber(),
+                emailData.getClientEmailAddress());
+
+        verify(emailProducer).sendEmail(
+                argThat(emailData -> "Identity reverified for client: Client Name".equals(emailData.getSubject())),
+                eq("acsp_client_reverification_email"));
+    }
+
+    @Test
+    void sendClientReverificationEmailFailure() throws EmailSendingException {
+        doThrow(EmailSendingException.class).when(emailProducer).sendEmail(any(EmailData.class), eq("acsp_client_reverification_email"));
+        assertThrows(EmailSendingException.class, () -> emailService.sendClientReverificationEmail(
+                emailData.getTo(),
+                emailData.getClientName(),
+                emailData.getReferenceNumber(),
+                emailData.getClientEmailAddress()));
     }
 }

--- a/src/test/java/uk/gov/companieshouse/acsp/service/EmailServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/acsp/service/EmailServiceTest.java
@@ -7,6 +7,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.companieshouse.acsp.models.email.ClientVerificationEmailData;
+import uk.gov.companieshouse.acsp.models.enums.ApplicationType;
 import uk.gov.companieshouse.email_producer.EmailProducer;
 import uk.gov.companieshouse.email_producer.EmailSendingException;
 import uk.gov.companieshouse.email_producer.model.EmailData;
@@ -44,7 +45,8 @@ public class EmailServiceTest {
                 emailData.getTo(),
                 emailData.getClientName(),
                 emailData.getReferenceNumber(),
-                emailData.getClientEmailAddress());
+                emailData.getClientEmailAddress(),
+                ApplicationType.VERIFICATION);
 
         verify(emailProducer).sendEmail(
                 argThat(emailData -> "Identity verified for client: Client Name".equals(emailData.getSubject())),
@@ -58,16 +60,18 @@ public class EmailServiceTest {
                 emailData.getTo(),
                 emailData.getClientName(),
                 emailData.getReferenceNumber(),
-                emailData.getClientEmailAddress()));
+                emailData.getClientEmailAddress(),
+                ApplicationType.VERIFICATION));
     }
 
     @Test
     void sendClientReverificationEmailSuccess() throws EmailSendingException {
-        emailService.sendClientReverificationEmail(
+        emailService.sendClientVerificationEmail(
                 emailData.getTo(),
                 emailData.getClientName(),
                 emailData.getReferenceNumber(),
-                emailData.getClientEmailAddress());
+                emailData.getClientEmailAddress(),
+                ApplicationType.REVERIFICATION);
 
         verify(emailProducer).sendEmail(
                 argThat(emailData -> "Identity reverified for client: Client Name".equals(emailData.getSubject())),
@@ -77,10 +81,11 @@ public class EmailServiceTest {
     @Test
     void sendClientReverificationEmailFailure() throws EmailSendingException {
         doThrow(EmailSendingException.class).when(emailProducer).sendEmail(any(EmailData.class), eq("acsp_client_reverification_email"));
-        assertThrows(EmailSendingException.class, () -> emailService.sendClientReverificationEmail(
+        assertThrows(EmailSendingException.class, () -> emailService.sendClientVerificationEmail(
                 emailData.getTo(),
                 emailData.getClientName(),
                 emailData.getReferenceNumber(),
-                emailData.getClientEmailAddress()));
+                emailData.getClientEmailAddress(),
+                ApplicationType.REVERIFICATION));
     }
 }


### PR DESCRIPTION
__Short description outlining key changes/additions__

- Added optional query parameter of `application_type` to match recent updates made to Verify and Reverify email sender.
- Re-using existing EmailService method through performing a check on application type to dynamically set the related email subject and email template
- If the request comes from the Reverify service, then query parameter is populated with the string "reverifcation".
- If the email is triggered from the Verify service then query parameter is populated with the string "verification".
- Set default application_type "verification" when no query parameter has been provided.
- Added enum values for verification and reverification 
- Added unit tests 


__JIRA Ticket Number__
[IDVA5-2643](https://companieshouse.atlassian.net/browse/IDVA5-2643)

### Type of change

* [ ] Bug fix
* [x] New feature
* [ ] Breaking change
* [ ] Infrastructure change

### Pull request checklist

* [x] I have added unit tests for new code that I have added
* [x] I have added/updated functional tests where appropriate
* [x] The code follows our [coding standards](https://github.com/companieshouse/styleguides/blob/master/java.md)

__An exhaustive list of peer review checks can be read [here](https://github.com/companieshouse/styleguides/blob/master/java_review.md#developer-actions-prior-to-code-commitreview-started)__

[IDVA5-2643]: https://companieshouse.atlassian.net/browse/IDVA5-2643?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ