### PR TITLE
asm-2317 : Sec vuln fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 		<main.class>uk.gov.companieshouse.acsp.AcspApplication</main.class>
 		<maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
 		<org.mapstruct.version>1.6.3</org.mapstruct.version>
-		<private-api-sdk-java.version>4.0.439</private-api-sdk-java.version>
+		<private-api-sdk-java.version>6.0.17</private-api-sdk-java.version>
 		<api-sdk-manager-java-library.version>3.0.15</api-sdk-manager-java-library.version>
 		<structured-logging.version>3.0.46</structured-logging.version>
 		<maven-surefire-plugin.version>3.2.5</maven-surefire-plugin.version>
@@ -49,7 +49,11 @@
 		<powermock-api-mockito2.version>2.0.9</powermock-api-mockito2.version>
 		<jib-maven-plugin.version>3.4.6</jib-maven-plugin.version>
 		<maven-checkstyle-plugin.version>2.17</maven-checkstyle-plugin.version>
+
+		<!-- Override properties -->
+		<tomcat-embed.version>10.1.55</tomcat-embed.version>
 	</properties>
+
 	<dependencyManagement>
 		<dependencies>
 			<dependency>
@@ -69,8 +73,26 @@
 				<artifactId>commons-lang3</artifactId>
         		<version>${commons-lang3.version}</version>
       		</dependency>
+
+			<!-- CVE-2026-41293, CVE-2026-41284, CVE-2026-43513, CVE-2026-43512, CVE-2026-42498, CVE-2026-43515 -->
+			<!-- Source: https://mvnrepository.com/artifact/org.apache.tomcat.embed/tomcat-embed-core -->
+			<dependency>
+				<groupId>org.apache.tomcat.embed</groupId>
+				<artifactId>tomcat-embed-core</artifactId>
+				<version>${tomcat-embed.version}</version>
+				<scope>compile</scope>
+			</dependency>
+			<!-- CVE-2026-41293, CVE-2026-41284, CVE-2026-43513, CVE-2026-43512, CVE-2026-42498, CVE-2026-43515 -->
+			<!-- Source: https://mvnrepository.com/artifact/org.apache.tomcat.embed/tomcat-embed-core -->
+			<dependency>
+				<groupId>org.apache.tomcat.embed</groupId>
+				<artifactId>tomcat-embed-websocket</artifactId>
+				<version>${tomcat-embed.version}</version>
+				<scope>compile</scope>
+			</dependency>
 		</dependencies>
 	</dependencyManagement>
+
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 	<description>ACSP workstream</description>
 	<properties>
 		<java.version>21</java.version>
-		<spring.boot.version>3.5.9</spring.boot.version>
+		<spring.boot.version>3.5.14</spring.boot.version>
 		<main.class>uk.gov.companieshouse.acsp.AcspApplication</main.class>
 		<maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
 		<org.mapstruct.version>1.6.3</org.mapstruct.version>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>uk.gov.companieshouse</groupId>
 		<artifactId>companies-house-parent</artifactId>
-		<version>2.1.12</version>
+		<version>2.1.14</version>
 		<relativePath/>
 	</parent>
 	<artifactId>acsp-api</artifactId>
@@ -40,8 +40,8 @@
 		<sonar.java.binaries>${project.basedir}/target</sonar.java.binaries>
 		<sonar.exclusions>**/models/**</sonar.exclusions>
 		<commons-io.version>2.21.0</commons-io.version>
-		<jetty-http2-server.version>12.1.5</jetty-http2-server.version>
-		<jetty-ee10-webapp.version>12.1.5</jetty-ee10-webapp.version>
+		<jetty-http2-server.version>12.1.9</jetty-http2-server.version>
+		<jetty-ee10-webapp.version>12.1.9</jetty-ee10-webapp.version>
 		<junit-jupiter.version>1.21.4</junit-jupiter.version>
 		<flexmark-all.version>0.42.14</flexmark-all.version>
 		<swagger-annotations.version>2.0.0-rc2</swagger-annotations.version>
@@ -64,11 +64,11 @@
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>
-      <dependency>
-        <groupId>org.apache.commons</groupId>
-        <artifactId>commons-lang3</artifactId>
-        <version>${commons-lang3.version}</version>
-      </dependency>
+      		<dependency>
+        		<groupId>org.apache.commons</groupId>
+				<artifactId>commons-lang3</artifactId>
+        		<version>${commons-lang3.version}</version>
+      		</dependency>
 		</dependencies>
 	</dependencyManagement>
 	<dependencies>


### PR DESCRIPTION
__Short description outlining key changes/additions__

Uplifted spring boot version to 3.5.14.
Uplifted CH parent version to 2.1.14.
Uplifted jetty versions to 12.1.9.
Uplifted private api sdk java to v 6.0.17.

Added transitive dependency override on tomcat-embed-core and tomcat-embed-websocket to address security vulnerabilities.

__JIRA Ticket Number__

[ASM-2317](https://companieshouse.atlassian.net/browse/ASM-2317)

### Type of change

* [ ] Bug fix
* [ ] New feature
* [ ] Breaking change
* [ ] Infrastructure change

### Pull request checklist

* [ ] I have added unit tests for new code that I have added
* [ ] I have added/updated functional tests where appropriate
* [ ] The code follows our [coding standards](https://github.com/companieshouse/styleguides/blob/master/java.md)

__An exhaustive list of peer review checks can be read [here](https://github.com/companieshouse/styleguides/blob/master/java_review.md#developer-actions-prior-to-code-commitreview-started)__

[ASM-2317]: https://companieshouse.atlassian.net/browse/ASM-2317?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ